### PR TITLE
Copy back missing docs and build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+branches:
+  only:
+    - master
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+
+dist: xenial
+sudo: required
+
+matrix:
+  fast_finish: true
+
+services:
+  - docker
+
+stages:
+  - name: tests
+  - name: release
+    if: tag IS present
+
+jobs:
+  include:
+    - stage: release
+      name: 'Release to Docker Hub'
+      script:
+        - make superset-docker-push-latest-release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## [Unreleased]
+<details>
+  <summary>
+    Changes that have landed in master but are not yet released.
+    Click to see more.
+  </summary>
+
+### New Features
+
+- Loading of default dashboards on bootstrap ([#71](https://github.com/src-d/superset-compose/issues/71)).
+- Update gitbase to v0.20.0 ([#81](https://github.com/src-d/superset-compose/issues/81)).
+- Update bblfsh to v2.14.0 ([#81](https://github.com/src-d/superset-compose/issues/81)).
+- Use sparksql instead of mysql for enterprise version ([#79](https://github.com/src-d/superset-compose/issues/79)).
+- Cancel query to database on stop ([#35](https://github.com/src-d/superset-compose/issues/35)).
+
+</details>
+
+## v0.0.1 - 2019-05-16
+
+The `srcd/superset` docker image is based on Superset 0.32, and contains the following additions:
+- an extra tab, UAST, to explore bblfsh parsing results.
+- SQL Lab contains a modal dialog to visualize columns that contain UAST.
+- source{d} branding.
+- SQLAlchemy dependency upgraded to 1.3, for compatibility with gitbase ([#18](https://github.com/src-d/superset-compose/issues/18)).
+- Backport an upstream fix for Hive Database connection ([#21](https://github.com/src-d/superset-compose/issues/21)).

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 # Package configuration
-PROJECT = sandbox-ce
+PROJECT = sourced-ui
 
 # superset upstream configuration
 SUPERSET_REPO = https://github.com/apache/incubator-superset.git
-SUPERSET_VERSION = release--0.32
+SUPERSET_VERSION = 0.32.0rc2
 SUPERSET_REMOTE = superset
 # directory to sync superset upstream with
 SUPERSET_DIR = superset
 # directory with custom code to copy into SUPERSET_DIR
 PATCH_SOURCE_DIR = srcd
 # name of the superset docker image to build
-SUPERSET_IMAGE_NAME = srcd/superset
+SUPERSET_IMAGE_NAME = srcd/sourced-ui
 
 # Including ci Makefile
 CI_REPOSITORY ?= https://github.com/src-d/ci.git
@@ -78,17 +78,12 @@ superset-remote-add:
 # Prints list of changed files in local superset and upstream
 .PHONY: diff-stat
 diff-stat: superset-remote-add
-	git diff-tree --stat $(SUPERSET_REMOTE)/$(SUPERSET_VERSION) HEAD:$(SUPERSET_DIR)/
+	git diff-tree --stat $(SUPERSET_VERSION) HEAD:$(SUPERSET_DIR)/
 
 # Prints unified diff of local superset  and upstream
 .PHONY: diff
 diff: superset-remote-add
-	git diff-tree -p $(SUPERSET_REMOTE)/$(SUPERSET_VERSION) HEAD:$(SUPERSET_DIR)/
-
-# Merge remote superset into SUPERSET_DIR as squashed commit
-.PHONY: merge
-merge: superset-remote-add
-	git merge --squash -s subtree --no-commit remotes/$(SUPERSET_REMOTE)/$(SUPERSET_VERSION)
+	git diff-tree -p $(SUPERSET_VERSION) HEAD:$(SUPERSET_DIR)/
 
 build: superset-build
 clean: superset-clean

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,94 @@
+# Package configuration
+PROJECT = sandbox-ce
+
+# superset upstream configuration
+SUPERSET_REPO = https://github.com/apache/incubator-superset.git
+SUPERSET_VERSION = release--0.32
+SUPERSET_REMOTE = superset
+# directory to sync superset upstream with
+SUPERSET_DIR = superset
+# directory with custom code to copy into SUPERSET_DIR
+PATCH_SOURCE_DIR = srcd
+# name of the superset docker image to build
+SUPERSET_IMAGE_NAME = srcd/superset
+
+# Including ci Makefile
+CI_REPOSITORY ?= https://github.com/src-d/ci.git
+CI_PATH ?= $(shell pwd)/.ci
+CI_VERSION ?= v1
+
+MAKEFILE := $(CI_PATH)/Makefile.main
+$(MAKEFILE):
+	git clone --quiet --branch $(CI_VERSION) --depth 1 $(CI_REPOSITORY) $(CI_PATH);
+
+-include $(MAKEFILE)
+
+all: superset-remote-add
+
+# Copy src-d files in the superset repository
+.PHONY: patch
+patch: clean
+	cp -r $(PATCH_SOURCE_DIR)/* $(SUPERSET_DIR)/
+
+# Copy src-d files in the superset repository using symlinks. it's useful for development.
+# Allows to run flask locally and work only inside superset directory.
+.PHONY: patch-dev
+patch-dev: clean
+	@diff=`diff -r $(PATCH_SOURCE_DIR) $(SUPERSET_DIR) | grep "$(PATCH_SOURCE_DIR)" | awk '{gsub(/: /,"/");print $$3}'`; \
+	for file in $${diff}; do \
+		to=`echo $${file} | cut -d'/' -f2-`; \
+		ln -s "$(PWD)/$${file}" "$(SUPERSET_DIR)/$${to}"; \
+	done; \
+	ln -s "$(PWD)/$(PATCH_SOURCE_DIR)/superset/superset_config_dev.py" "$(SUPERSET_DIR)/superset_config.py"; \
+
+# Create docker image
+.PHONY: superset-build
+superset-build: patch
+	docker build -t $(SUPERSET_IMAGE_NAME):$(VERSION) -f superset/contrib/docker/Dockerfile superset
+
+# Push the superset docker image, based on .ci/Makefile.main
+superset-docker-push: docker-login superset-build
+	@if [ "$(BRANCH)" == "master" && "$(DOCKER_PUSH_MASTER)" == "" ]; then \
+		echo "docker-push is disabled on master branch" \
+		exit 1; \
+	fi; \
+	docker push $(SUPERSET_IMAGE_NAME):$(VERSION); \
+	if [ -n "$(DOCKER_PUSH_LATEST)" ]; then \
+		docker tag $(SUPERSET_IMAGE_NAME):$(VERSION) \
+			$(SUPERSET_IMAGE_NAME):latest; \
+		docker push $(SUPERSET_IMAGE_NAME):latest; \
+	fi;
+
+superset-docker-push-latest-release:
+	@DOCKER_PUSH_LATEST=$(IS_RELEASE) make superset-docker-push
+
+# Clean superset directory from copied files
+.PHONY: superset-clean
+superset-clean:
+	rm -f "$(SUPERSET_DIR)/superset_config.py"
+	git clean -fd $(SUPERSET_DIR)
+
+# Add superset upstream remote if doesn't exists
+.PHONY: superset-remote-add
+superset-remote-add:
+	@if ! git remote | grep -q superset; then \
+		git remote add -f $(SUPERSET_REMOTE) $(SUPERSET_REPO); \
+	fi; \
+
+# Prints list of changed files in local superset and upstream
+.PHONY: diff-stat
+diff-stat: superset-remote-add
+	git diff-tree --stat $(SUPERSET_REMOTE)/$(SUPERSET_VERSION) HEAD:$(SUPERSET_DIR)/
+
+# Prints unified diff of local superset  and upstream
+.PHONY: diff
+diff: superset-remote-add
+	git diff-tree -p $(SUPERSET_REMOTE)/$(SUPERSET_VERSION) HEAD:$(SUPERSET_DIR)/
+
+# Merge remote superset into SUPERSET_DIR as squashed commit
+.PHONY: merge
+merge: superset-remote-add
+	git merge --squash -s subtree --no-commit remotes/$(SUPERSET_REMOTE)/$(SUPERSET_VERSION)
+
+build: superset-build
+clean: superset-clean

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
-Source{d} UI
+# source{d} UI
+
+## Contents
+
+- [Development](#development)
+
+## Development
+
+### Setup local environment
+
+Run dependencies using docker-compose:
+```
+docker-compose up gitbase bblfsh-web
+```
+
+Update superset directory:
+
+```
+make patch-dev
+```
+
+Enter into `superset` directory:
+```
+cd superset
+```
+
+Follow original superset instructions for [Flask server](https://github.com/apache/incubator-superset/blob/release--0.32/CONTRIBUTING.md#flask-server) and [Frontend assets](https://github.com/apache/incubator-superset/blob/release--0.32/CONTRIBUTING.md#frontend-assets)
+
+
+### Build docker image
+
+```
+VERSION=latest make build
+```
+
+The image name is defined in the `Makefile`.
+
+### Work with superset upstream
+
+Superset version which we are based on is defined in `Makefile`.
+
+To see which files are patched compare to upstream, run:
+
+```
+make diff-stat
+```
+
+To see diff with upstream, run:
+
+```
+make diff
+```
+
+To merge updated upsteam into subdirectory:
+
+```
+make merge
+```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Setup local environment
 
-Run dependencies using docker-compose:
+Download the `docker-compose.yml` file from [`src-d/sourced-ce`](https://github.com/src-d/sourced-ce), and run the dependencies:
 ```
 docker-compose up gitbase bblfsh-web
 ```
@@ -49,10 +49,4 @@ To see diff with upstream, run:
 
 ```
 make diff
-```
-
-To merge updated upsteam into subdirectory:
-
-```
-make merge
 ```


### PR DESCRIPTION
Part of #78.

Instead of overriding `build` I left `superset-build` as a new target. Without `COMMANDS` defined the go `build` does nothing, and this way `make build` does not complain about ignored commands.