### PR TITLE
Add gitbase-spark-connector support

### DIFF
--- a/srcd/contrib/docker/add_gitbase.py
+++ b/srcd/contrib/docker/add_gitbase.py
@@ -22,13 +22,14 @@ def get_or_create_gitbase_db():
 
 
 def add_gitbase_tables():
+    schema = conf.get('GITBASE_DB')
     dbobj = get_or_create_gitbase_db()
     TBL = ConnectorRegistry.sources['table']
-    for table in dbobj.all_table_names_in_schema('gitbase'):
+    for table in dbobj.all_table_names_in_schema(schema):
         # table_name should match the one in the datasource for fetch_metadata to work
         if db.session.query(TBL).filter_by(table_name=table).first():
             continue
-        if db.session.query(TBL).filter_by(table_name='gitbase.' + table).first():
+        if db.session.query(TBL).filter_by(table_name='%s.%s' % (schema, table)).first():
             continue
 
         # create table with original name and fetch columns
@@ -39,7 +40,7 @@ def add_gitbase_tables():
         tbl.fetch_metadata()
 
         # rename with prefix and set source
-        tbl.table_name = 'gitbase.' + table
+        tbl.table_name = '%s.%s' % (schema, table)
         tbl.sql = 'select * from ' + table
         db.session.add(dbobj)
         db.session.commit()

--- a/superset/contrib/docker/superset_config.py
+++ b/superset/contrib/docker/superset_config.py
@@ -71,18 +71,20 @@ CELERY_CONFIG = CeleryConfig
 # Gitbase configuration
 
 IS_EE = get_env_variable('MODE', 'Community') == 'Enterprise'
-GITBASE_USER = get_env_variable('GITBASE_USER')
+GITBASE_USER = get_env_variable('GITBASE_USER', '')
 GITBASE_PASSWORD = get_env_variable('GITBASE_PASSWORD', '')
 GITBASE_HOST = get_env_variable('GITBASE_HOST')
 GITBASE_PORT = get_env_variable('GITBASE_PORT')
 GITBASE_DB = get_env_variable('GITBASE_DB')
 GITBASE_PREFIX = 'sparksql' if IS_EE else 'mysql'
-GITBASE_DATABASE_URI = '%s://%s:%s@%s:%s/%s' % (GITBASE_PREFIX,
-                                                GITBASE_USER,
-                                                GITBASE_PASSWORD,
-                                                GITBASE_HOST,
-                                                GITBASE_PORT,
-                                                GITBASE_DB)
+GITBASE_AUTH = ''
+if GITBASE_USER:
+    GITBASE_AUTH = '%s%s@' % (GITBASE_USER, ':%s' % GITBASE_PASSWORD if GITBASE_PASSWORD else '')
+GITBASE_DATABASE_URI = '%s://%s%s:%s/%s' % (GITBASE_PREFIX,
+                                            GITBASE_AUTH,
+                                            GITBASE_HOST,
+                                            GITBASE_PORT,
+                                            GITBASE_DB)
 
 SQLLAB_DEFAULT_DBID = 2  # set gitbase as default DB in SQL Lab
 

--- a/superset/requirements-dev.txt
+++ b/superset/requirements-dev.txt
@@ -25,7 +25,7 @@ mysqlclient==1.3.13
 pip-tools==3.6.1
 psycopg2-binary==2.7.5
 pycodestyle==2.4.0
-pyhive==0.6.1
+-e git+https://github.com/src-d/PyHive.git@master#egg=PyHive
 pylint==1.9.2
 python-dotenv==0.10.1
 redis==2.10.6

--- a/superset/requirements-dev.txt
+++ b/superset/requirements-dev.txt
@@ -25,7 +25,7 @@ mysqlclient==1.3.13
 pip-tools==3.6.1
 psycopg2-binary==2.7.5
 pycodestyle==2.4.0
--e git+https://github.com/src-d/PyHive.git@master#egg=PyHive
+-e git+https://github.com/src-d/PyHive.git@v0.7.0-srcd1#egg=PyHive
 pylint==1.9.2
 python-dotenv==0.10.1
 redis==2.10.6


### PR DESCRIPTION
- Use patched version of PyHive
- Update config script to produce correct connection string without name
and password (currently gsc requires connection without user/pass)

Signed-off-by: Maxim Sukharev <max@smacker.ru>