### PR TITLE
Bump changelog for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,16 @@
     Click to see more.
   </summary>
 
-### New Features
-
-- Loading of default dashboards on bootstrap ([#71](https://github.com/src-d/superset-compose/issues/71)).
-- Update gitbase to v0.20.0 ([#81](https://github.com/src-d/superset-compose/issues/81)).
-- Update bblfsh to v2.14.0 ([#81](https://github.com/src-d/superset-compose/issues/81)).
-- Use sparksql instead of mysql for enterprise version ([#79](https://github.com/src-d/superset-compose/issues/79)).
-- Cancel query to database on stop ([#35](https://github.com/src-d/superset-compose/issues/35)).
-
 </details>
 
-## v0.0.1 - 2019-05-16
+## [v0.1.0](https://github.com/src-d/sourced-ui/releases/tag/v0.1.0) - 2019-06-03
 
-The `srcd/superset` docker image is based on Superset 0.32, and contains the following additions:
-- an extra tab, UAST, to explore bblfsh parsing results.
+The `srcd/sourced-ui` docker image is based on Superset 0.32, and contains the following additions:
+- An extra tab, UAST, to explore bblfsh parsing results.
 - SQL Lab contains a modal dialog to visualize columns that contain UAST.
 - source{d} branding.
-- SQLAlchemy dependency upgraded to 1.3, for compatibility with gitbase ([#18](https://github.com/src-d/superset-compose/issues/18)).
-- Backport an upstream fix for Hive Database connection ([#21](https://github.com/src-d/superset-compose/issues/21)).
+- Loading of default dashboards on bootstrap.
+- Creation of a default user on bootstrap, `admin`/`admin`.
+- SQLAlchemy dependency upgraded to 1.3, for compatibility with gitbase ([#18](https://github.com/src-d/sourced-ui/issues/18)).
+- Backport an upstream fix for Hive Database connection ([#21](https://github.com/src-d/sourced-ui/issues/21)).
+- Cancel database queries on stop ([#35](https://github.com/src-d/sourced-ui/issues/35)).


### PR DESCRIPTION
I think the repo is ready to release.

Since we changed the docker image name after the release, I think we can consider this one the first release. After this one is merged and tagged we can remove the GitHub release for 0.0.1.