### PR TITLE
Allow SUPERSET_IMAGE_NAME to be overwritten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SUPERSET_DIR = superset
 # directory with custom code to copy into SUPERSET_DIR
 PATCH_SOURCE_DIR = srcd
 # name of the superset docker image to build
-SUPERSET_IMAGE_NAME = srcd/sourced-ui
+SUPERSET_IMAGE_NAME ?= srcd/sourced-ui
 
 # Including ci Makefile
 CI_REPOSITORY ?= https://github.com/src-d/ci.git


### PR DESCRIPTION
This is interesting/necessary if you want to build test images with
different name and upload them to DockerHub

Signed-off-by: Rafael Porres Molina <rafa@sourced.tech>