### PR TITLE
Add dashboard based on metadata

### DIFF
--- a/srcd/dashboards/gitbase/welcome.json
+++ b/srcd/dashboards/gitbase/welcome.json
@@ -1,3948 +1,3714 @@
 {
-    "dashboards": [{
-        "__Dashboard__": {
-            "css": "",
-            "position_json": "{\"CHART-041PHv_MRw\":{\"children\":[],\"id\":\"CHART-041PHv_MRw\",\"meta\":{\"chartId\":5,\"height\":50,\"sliceName\":\"Number of commits per day of the week\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-hD1w3jICYS\"],\"type\":\"CHART\"},\"CHART-6u-O9zaawH\":{\"children\":[],\"id\":\"CHART-6u-O9zaawH\",\"meta\":{\"chartId\":22,\"height\":24,\"sliceName\":\"Repository by number of collaborators\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-FUc3gUSTRO\",\"COLUMN-vJhcpSQ1z2\",\"ROW-r-ExXo7qLY\"],\"type\":\"CHART\"},\"CHART-AP66HrubVI\":{\"children\":[],\"id\":\"CHART-AP66HrubVI\",\"meta\":{\"chartId\":3,\"height\":50,\"sliceName\":\"Commits Evolution\",\"width\":8},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-hD1w3jICYS\"],\"type\":\"CHART\"},\"CHART-DKXi5_xppH\":{\"children\":[],\"id\":\"CHART-DKXi5_xppH\",\"meta\":{\"chartId\":18,\"height\":50,\"sliceName\":\"Number of contributions per organization\",\"width\":5},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-eiNNHXGrgs\"],\"type\":\"CHART\"},\"CHART-Gb3oayXRWh\":{\"children\":[],\"id\":\"CHART-Gb3oayXRWh\",\"meta\":{\"chartId\":19,\"height\":50,\"sliceName\":\"Organization wordcloud\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-eiNNHXGrgs\",\"COLUMN-KMn1AWkAZw\"],\"type\":\"CHART\"},\"CHART-IRl6a81IDe\":{\"children\":[],\"id\":\"CHART-IRl6a81IDe\",\"meta\":{\"chartId\":6,\"height\":50,\"sliceName\":\"Compliance score\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-ynQWyCPKih\"],\"type\":\"CHART\"},\"CHART-J0kRUqPROS\":{\"children\":[],\"id\":\"CHART-J0kRUqPROS\",\"meta\":{\"chartId\":20,\"height\":50,\"sliceName\":\"Number of contributions per email\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-zEiM4-hrfS\",\"COLUMN-G9CulBOXBg\"],\"type\":\"CHART\"},\"CHART-J2vvzP-aHf\":{\"children\":[],\"id\":\"CHART-J2vvzP-aHf\",\"meta\":{\"chartId\":12,\"height\":33,\"sliceName\":\"Number of commits to HEAD per month\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-xpq95QSNi8\",\"COLUMN-WUmLX2QcTv\"],\"type\":\"CHART\"},\"CHART-QDR6YSJs6l\":{\"children\":[],\"id\":\"CHART-QDR6YSJs6l\",\"meta\":{\"chartId\":1,\"height\":24,\"sliceName\":\"Repository Count\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-FUc3gUSTRO\",\"COLUMN-p2tfT8G0yH\",\"ROW-1GPxzaxRVl\"],\"type\":\"CHART\"},\"CHART-SdGfHCf4OM\":{\"children\":[],\"id\":\"CHART-SdGfHCf4OM\",\"meta\":{\"chartId\":21,\"height\":50,\"sliceName\":\"Email wordcloud\",\"width\":7},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-zEiM4-hrfS\"],\"type\":\"CHART\"},\"CHART-VqMYjcjbwC\":{\"children\":[],\"id\":\"CHART-VqMYjcjbwC\",\"meta\":{\"chartId\":11,\"height\":26,\"sliceName\":\"Number of releases per month and repository\",\"width\":12},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-1wdi8YWyo3\"],\"type\":\"CHART\"},\"CHART-Xmt5TSjqCz\":{\"children\":[],\"id\":\"CHART-Xmt5TSjqCz\",\"meta\":{\"chartId\":13,\"height\":35,\"sliceName\":\"Number of commits per month breakdown per repo\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-xpq95QSNi8\",\"COLUMN-WUmLX2QcTv\"],\"type\":\"CHART\"},\"CHART-g3HfBmugbt\":{\"children\":[],\"id\":\"CHART-g3HfBmugbt\",\"meta\":{\"chartId\":7,\"height\":50,\"sliceName\":\"Missing files\",\"width\":8},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-ynQWyCPKih\"],\"type\":\"CHART\"},\"CHART-h7RcvUrFvM\":{\"children\":[],\"id\":\"CHART-h7RcvUrFvM\",\"meta\":{\"chartId\":15,\"height\":50,\"sliceName\":\"Number of files per languages\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-Orpw09D1Xl\",\"COLUMN-J334JJKtC8\"],\"type\":\"CHART\"},\"CHART-hbx1LJ_mGN\":{\"children\":[],\"id\":\"CHART-hbx1LJ_mGN\",\"meta\":{\"chartId\":8,\"height\":14,\"sliceName\":\"Files missing summary\",\"width\":12},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-_9fTlWqXxA\"],\"type\":\"CHART\"},\"CHART-khRv3WBU_V\":{\"children\":[],\"id\":\"CHART-khRv3WBU_V\",\"meta\":{\"chartId\":14,\"height\":40,\"sliceName\":\"Total number of commits per repository\",\"width\":12},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-gM6bL4qyS2\"],\"type\":\"CHART\"},\"CHART-lR1E2C98E5\":{\"children\":[],\"id\":\"CHART-lR1E2C98E5\",\"meta\":{\"chartId\":23,\"height\":50,\"sliceName\":\"Languages\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-FUc3gUSTRO\",\"COLUMN-CVmDdXys5d\"],\"type\":\"CHART\"},\"CHART-mvtzip4PDs\":{\"children\":[],\"id\":\"CHART-mvtzip4PDs\",\"meta\":{\"chartId\":4,\"height\":24,\"sliceName\":\"Repositories by number of files\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-FUc3gUSTRO\",\"COLUMN-vJhcpSQ1z2\"],\"type\":\"CHART\"},\"CHART-sQVAlEKKA4\":{\"children\":[],\"id\":\"CHART-sQVAlEKKA4\",\"meta\":{\"chartId\":17,\"height\":50,\"sliceName\":\"Number of lines of code per language\",\"width\":6},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-Orpw09D1Xl\"],\"type\":\"CHART\"},\"CHART-upuPfTlaDi\":{\"children\":[],\"id\":\"CHART-upuPfTlaDi\",\"meta\":{\"chartId\":10,\"height\":24,\"sliceName\":\"Number of collaborators\",\"width\":3},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-FUc3gUSTRO\",\"COLUMN-p2tfT8G0yH\"],\"type\":\"CHART\"},\"COLUMN-CVmDdXys5d\":{\"children\":[\"CHART-lR1E2C98E5\"],\"id\":\"COLUMN-CVmDdXys5d\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-FUc3gUSTRO\"],\"type\":\"COLUMN\"},\"COLUMN-G9CulBOXBg\":{\"children\":[\"CHART-J0kRUqPROS\"],\"id\":\"COLUMN-G9CulBOXBg\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\",\"width\":5},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-zEiM4-hrfS\"],\"type\":\"COLUMN\"},\"COLUMN-J334JJKtC8\":{\"children\":[\"CHART-h7RcvUrFvM\"],\"id\":\"COLUMN-J334JJKtC8\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\",\"width\":6},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-Orpw09D1Xl\"],\"type\":\"COLUMN\"},\"COLUMN-KMn1AWkAZw\":{\"children\":[\"CHART-Gb3oayXRWh\"],\"id\":\"COLUMN-KMn1AWkAZw\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\",\"width\":7},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-eiNNHXGrgs\"],\"type\":\"COLUMN\"},\"COLUMN-WUmLX2QcTv\":{\"children\":[\"CHART-J2vvzP-aHf\",\"CHART-Xmt5TSjqCz\"],\"id\":\"COLUMN-WUmLX2QcTv\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\",\"width\":12},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-xpq95QSNi8\"],\"type\":\"COLUMN\"},\"COLUMN-p2tfT8G0yH\":{\"children\":[\"ROW-1GPxzaxRVl\",\"CHART-upuPfTlaDi\"],\"id\":\"COLUMN-p2tfT8G0yH\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-FUc3gUSTRO\"],\"type\":\"COLUMN\"},\"COLUMN-vJhcpSQ1z2\":{\"children\":[\"CHART-mvtzip4PDs\",\"ROW-r-ExXo7qLY\"],\"id\":\"COLUMN-vJhcpSQ1z2\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-FUc3gUSTRO\"],\"type\":\"COLUMN\"},\"DASHBOARD_VERSION_KEY\":\"v2\",\"GRID_ID\":{\"children\":[\"ROW-FUc3gUSTRO\",\"HEADER-342YbpwTbO\",\"ROW-1wdi8YWyo3\",\"HEADER-iYAQf-B8KA\",\"ROW-hD1w3jICYS\",\"ROW-xpq95QSNi8\",\"ROW-gM6bL4qyS2\",\"HEADER-kqzu-HPiFQ\",\"ROW-Orpw09D1Xl\",\"HEADER-itQ10OjSQq\",\"ROW-eiNNHXGrgs\",\"ROW-zEiM4-hrfS\",\"HEADER-hnogkcMo8S\",\"ROW-ynQWyCPKih\",\"ROW-_9fTlWqXxA\"],\"id\":\"GRID_ID\",\"parents\":[\"ROOT_ID\"],\"type\":\"GRID\"},\"HEADER-342YbpwTbO\":{\"children\":[],\"id\":\"HEADER-342YbpwTbO\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\",\"headerSize\":\"MEDIUM_HEADER\",\"text\":\"Release activity\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"HEADER\"},\"HEADER-hnogkcMo8S\":{\"children\":[],\"id\":\"HEADER-hnogkcMo8S\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\",\"headerSize\":\"MEDIUM_HEADER\",\"text\":\"Compliance metrics\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"HEADER\"},\"HEADER-iYAQf-B8KA\":{\"children\":[],\"id\":\"HEADER-iYAQf-B8KA\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\",\"headerSize\":\"MEDIUM_HEADER\",\"text\":\"Commit activity\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"HEADER\"},\"HEADER-itQ10OjSQq\":{\"children\":[],\"id\":\"HEADER-itQ10OjSQq\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\",\"headerSize\":\"MEDIUM_HEADER\",\"text\":\"Contributors analysis\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"HEADER\"},\"HEADER-kqzu-HPiFQ\":{\"children\":[],\"id\":\"HEADER-kqzu-HPiFQ\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\",\"headerSize\":\"MEDIUM_HEADER\",\"text\":\"Languages\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"HEADER\"},\"HEADER_ID\":{\"id\":\"HEADER_ID\",\"meta\":{\"text\":\"Welcome\"},\"type\":\"HEADER\"},\"ROOT_ID\":{\"children\":[\"GRID_ID\"],\"id\":\"ROOT_ID\",\"type\":\"ROOT\"},\"ROW-1GPxzaxRVl\":{\"children\":[\"CHART-QDR6YSJs6l\"],\"id\":\"ROW-1GPxzaxRVl\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-FUc3gUSTRO\",\"COLUMN-p2tfT8G0yH\"],\"type\":\"ROW\"},\"ROW-1wdi8YWyo3\":{\"children\":[\"CHART-VqMYjcjbwC\"],\"id\":\"ROW-1wdi8YWyo3\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-FUc3gUSTRO\":{\"children\":[\"COLUMN-p2tfT8G0yH\",\"COLUMN-CVmDdXys5d\",\"COLUMN-vJhcpSQ1z2\"],\"id\":\"ROW-FUc3gUSTRO\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-Orpw09D1Xl\":{\"children\":[\"COLUMN-J334JJKtC8\",\"CHART-sQVAlEKKA4\"],\"id\":\"ROW-Orpw09D1Xl\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-_9fTlWqXxA\":{\"children\":[\"CHART-hbx1LJ_mGN\"],\"id\":\"ROW-_9fTlWqXxA\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-eiNNHXGrgs\":{\"children\":[\"CHART-DKXi5_xppH\",\"COLUMN-KMn1AWkAZw\"],\"id\":\"ROW-eiNNHXGrgs\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-gM6bL4qyS2\":{\"children\":[\"CHART-khRv3WBU_V\"],\"id\":\"ROW-gM6bL4qyS2\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-hD1w3jICYS\":{\"children\":[\"CHART-AP66HrubVI\",\"CHART-041PHv_MRw\"],\"id\":\"ROW-hD1w3jICYS\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-r-ExXo7qLY\":{\"children\":[\"CHART-6u-O9zaawH\"],\"id\":\"ROW-r-ExXo7qLY\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-FUc3gUSTRO\",\"COLUMN-vJhcpSQ1z2\"],\"type\":\"ROW\"},\"ROW-xpq95QSNi8\":{\"children\":[\"COLUMN-WUmLX2QcTv\"],\"id\":\"ROW-xpq95QSNi8\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-ynQWyCPKih\":{\"children\":[\"CHART-IRl6a81IDe\",\"CHART-g3HfBmugbt\"],\"id\":\"ROW-ynQWyCPKih\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-zEiM4-hrfS\":{\"children\":[\"COLUMN-G9CulBOXBg\",\"CHART-SdGfHCf4OM\"],\"id\":\"ROW-zEiM4-hrfS\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"}}",
-            "id": 1,
-            "created_on": {
-                "__datetime__": "2019-06-13T10:16:06"
-            },
-            "created_by_fk": null,
-            "json_metadata": "{\"filter_immune_slices\": [], \"timed_refresh_immune_slices\": [], \"filter_immune_slice_fields\": {}, \"expanded_slices\": {}, \"default_filters\": \"{}\", \"remote_id\": 1, \"import_time\": 1560421533, \"refresh_frequency\": 0}",
-            "description": null,
-            "dashboard_title": "Welcome",
+  "dashboards": [
+    {
+      "__Dashboard__": {
+        "position_json": "{\"CHART-041PHv_MRw\": {\"children\": [], \"id\": \"CHART-041PHv_MRw\", \"meta\": {\"chartId\": 4, \"height\": 50, \"sliceName\": \"Number of commits per day of the week\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-hD1w3jICYS\"], \"type\": \"CHART\"}, \"CHART-6u-O9zaawH\": {\"children\": [], \"id\": \"CHART-6u-O9zaawH\", \"meta\": {\"chartId\": 19, \"height\": 24, \"sliceName\": \"Repository by number of collaborators\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-FUc3gUSTRO\", \"COLUMN-vJhcpSQ1z2\", \"ROW-r-ExXo7qLY\"], \"type\": \"CHART\"}, \"CHART-AP66HrubVI\": {\"children\": [], \"id\": \"CHART-AP66HrubVI\", \"meta\": {\"chartId\": 2, \"height\": 50, \"sliceName\": \"Commits Evolution\", \"width\": 8}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-hD1w3jICYS\"], \"type\": \"CHART\"}, \"CHART-DKXi5_xppH\": {\"children\": [], \"id\": \"CHART-DKXi5_xppH\", \"meta\": {\"chartId\": 15, \"height\": 50, \"sliceName\": \"Number of contributions per organization\", \"width\": 5}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-eiNNHXGrgs\"], \"type\": \"CHART\"}, \"CHART-Gb3oayXRWh\": {\"children\": [], \"id\": \"CHART-Gb3oayXRWh\", \"meta\": {\"chartId\": 16, \"height\": 50, \"sliceName\": \"Organization wordcloud\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-eiNNHXGrgs\", \"COLUMN-KMn1AWkAZw\"], \"type\": \"CHART\"}, \"CHART-IRl6a81IDe\": {\"children\": [], \"id\": \"CHART-IRl6a81IDe\", \"meta\": {\"chartId\": 5, \"height\": 50, \"sliceName\": \"Compliance score\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-ynQWyCPKih\"], \"type\": \"CHART\"}, \"CHART-J0kRUqPROS\": {\"children\": [], \"id\": \"CHART-J0kRUqPROS\", \"meta\": {\"chartId\": 17, \"height\": 50, \"sliceName\": \"Number of contributions per email\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-zEiM4-hrfS\", \"COLUMN-G9CulBOXBg\"], \"type\": \"CHART\"}, \"CHART-J2vvzP-aHf\": {\"children\": [], \"id\": \"CHART-J2vvzP-aHf\", \"meta\": {\"chartId\": 10, \"height\": 33, \"sliceName\": \"Number of commits to HEAD per month\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-xpq95QSNi8\", \"COLUMN-WUmLX2QcTv\"], \"type\": \"CHART\"}, \"CHART-QDR6YSJs6l\": {\"children\": [], \"id\": \"CHART-QDR6YSJs6l\", \"meta\": {\"chartId\": 1, \"height\": 24, \"sliceName\": \"Repository Count\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-FUc3gUSTRO\", \"COLUMN-p2tfT8G0yH\", \"ROW-1GPxzaxRVl\"], \"type\": \"CHART\"}, \"CHART-SdGfHCf4OM\": {\"children\": [], \"id\": \"CHART-SdGfHCf4OM\", \"meta\": {\"chartId\": 18, \"height\": 50, \"sliceName\": \"Email wordcloud\", \"width\": 7}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-zEiM4-hrfS\"], \"type\": \"CHART\"}, \"CHART-VqMYjcjbwC\": {\"children\": [], \"id\": \"CHART-VqMYjcjbwC\", \"meta\": {\"chartId\": 9, \"height\": 26, \"sliceName\": \"Number of releases per month and repository\", \"width\": 12}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-1wdi8YWyo3\"], \"type\": \"CHART\"}, \"CHART-Xmt5TSjqCz\": {\"children\": [], \"id\": \"CHART-Xmt5TSjqCz\", \"meta\": {\"chartId\": 11, \"height\": 35, \"sliceName\": \"Number of commits per month breakdown per repo\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-xpq95QSNi8\", \"COLUMN-WUmLX2QcTv\"], \"type\": \"CHART\"}, \"CHART-g3HfBmugbt\": {\"children\": [], \"id\": \"CHART-g3HfBmugbt\", \"meta\": {\"chartId\": 6, \"height\": 50, \"sliceName\": \"Missing files\", \"width\": 8}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-ynQWyCPKih\"], \"type\": \"CHART\"}, \"CHART-h7RcvUrFvM\": {\"children\": [], \"id\": \"CHART-h7RcvUrFvM\", \"meta\": {\"chartId\": 13, \"height\": 50, \"sliceName\": \"Number of files per languages\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-Orpw09D1Xl\", \"COLUMN-J334JJKtC8\"], \"type\": \"CHART\"}, \"CHART-hbx1LJ_mGN\": {\"children\": [], \"id\": \"CHART-hbx1LJ_mGN\", \"meta\": {\"chartId\": 7, \"height\": 14, \"sliceName\": \"Files missing summary\", \"width\": 12}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-_9fTlWqXxA\"], \"type\": \"CHART\"}, \"CHART-khRv3WBU_V\": {\"children\": [], \"id\": \"CHART-khRv3WBU_V\", \"meta\": {\"chartId\": 12, \"height\": 40, \"sliceName\": \"Total number of commits per repository\", \"width\": 12}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-gM6bL4qyS2\"], \"type\": \"CHART\"}, \"CHART-lR1E2C98E5\": {\"children\": [], \"id\": \"CHART-lR1E2C98E5\", \"meta\": {\"chartId\": 20, \"height\": 50, \"sliceName\": \"Languages\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-FUc3gUSTRO\", \"COLUMN-CVmDdXys5d\"], \"type\": \"CHART\"}, \"CHART-mvtzip4PDs\": {\"children\": [], \"id\": \"CHART-mvtzip4PDs\", \"meta\": {\"chartId\": 3, \"height\": 24, \"sliceName\": \"Repositories by number of files\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-FUc3gUSTRO\", \"COLUMN-vJhcpSQ1z2\"], \"type\": \"CHART\"}, \"CHART-sQVAlEKKA4\": {\"children\": [], \"id\": \"CHART-sQVAlEKKA4\", \"meta\": {\"chartId\": 14, \"height\": 50, \"sliceName\": \"Number of lines of code per language\", \"width\": 6}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-Orpw09D1Xl\"], \"type\": \"CHART\"}, \"CHART-upuPfTlaDi\": {\"children\": [], \"id\": \"CHART-upuPfTlaDi\", \"meta\": {\"chartId\": 8, \"height\": 24, \"sliceName\": \"Number of collaborators\", \"width\": 3}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-FUc3gUSTRO\", \"COLUMN-p2tfT8G0yH\"], \"type\": \"CHART\"}, \"COLUMN-CVmDdXys5d\": {\"children\": [\"CHART-lR1E2C98E5\"], \"id\": \"COLUMN-CVmDdXys5d\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-FUc3gUSTRO\"], \"type\": \"COLUMN\"}, \"COLUMN-G9CulBOXBg\": {\"children\": [\"CHART-J0kRUqPROS\"], \"id\": \"COLUMN-G9CulBOXBg\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\", \"width\": 5}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-zEiM4-hrfS\"], \"type\": \"COLUMN\"}, \"COLUMN-J334JJKtC8\": {\"children\": [\"CHART-h7RcvUrFvM\"], \"id\": \"COLUMN-J334JJKtC8\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\", \"width\": 6}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-Orpw09D1Xl\"], \"type\": \"COLUMN\"}, \"COLUMN-KMn1AWkAZw\": {\"children\": [\"CHART-Gb3oayXRWh\"], \"id\": \"COLUMN-KMn1AWkAZw\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\", \"width\": 7}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-eiNNHXGrgs\"], \"type\": \"COLUMN\"}, \"COLUMN-WUmLX2QcTv\": {\"children\": [\"CHART-J2vvzP-aHf\", \"CHART-Xmt5TSjqCz\"], \"id\": \"COLUMN-WUmLX2QcTv\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\", \"width\": 12}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-xpq95QSNi8\"], \"type\": \"COLUMN\"}, \"COLUMN-p2tfT8G0yH\": {\"children\": [\"ROW-1GPxzaxRVl\", \"CHART-upuPfTlaDi\"], \"id\": \"COLUMN-p2tfT8G0yH\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-FUc3gUSTRO\"], \"type\": \"COLUMN\"}, \"COLUMN-vJhcpSQ1z2\": {\"children\": [\"CHART-mvtzip4PDs\", \"ROW-r-ExXo7qLY\"], \"id\": \"COLUMN-vJhcpSQ1z2\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-FUc3gUSTRO\"], \"type\": \"COLUMN\"}, \"DASHBOARD_VERSION_KEY\": \"v2\", \"GRID_ID\": {\"children\": [\"ROW-FUc3gUSTRO\", \"HEADER-342YbpwTbO\", \"ROW-1wdi8YWyo3\", \"HEADER-iYAQf-B8KA\", \"ROW-hD1w3jICYS\", \"ROW-xpq95QSNi8\", \"ROW-gM6bL4qyS2\", \"HEADER-kqzu-HPiFQ\", \"ROW-Orpw09D1Xl\", \"HEADER-itQ10OjSQq\", \"ROW-eiNNHXGrgs\", \"ROW-zEiM4-hrfS\", \"HEADER-hnogkcMo8S\", \"ROW-ynQWyCPKih\", \"ROW-_9fTlWqXxA\"], \"id\": \"GRID_ID\", \"parents\": [\"ROOT_ID\"], \"type\": \"GRID\"}, \"HEADER-342YbpwTbO\": {\"children\": [], \"id\": \"HEADER-342YbpwTbO\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\", \"headerSize\": \"MEDIUM_HEADER\", \"text\": \"Release activity\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"HEADER\"}, \"HEADER-hnogkcMo8S\": {\"children\": [], \"id\": \"HEADER-hnogkcMo8S\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\", \"headerSize\": \"MEDIUM_HEADER\", \"text\": \"Compliance metrics\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"HEADER\"}, \"HEADER-iYAQf-B8KA\": {\"children\": [], \"id\": \"HEADER-iYAQf-B8KA\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\", \"headerSize\": \"MEDIUM_HEADER\", \"text\": \"Commit activity\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"HEADER\"}, \"HEADER-itQ10OjSQq\": {\"children\": [], \"id\": \"HEADER-itQ10OjSQq\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\", \"headerSize\": \"MEDIUM_HEADER\", \"text\": \"Contributors analysis\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"HEADER\"}, \"HEADER-kqzu-HPiFQ\": {\"children\": [], \"id\": \"HEADER-kqzu-HPiFQ\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\", \"headerSize\": \"MEDIUM_HEADER\", \"text\": \"Languages\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"HEADER\"}, \"HEADER_ID\": {\"id\": \"HEADER_ID\", \"meta\": {\"text\": \"Welcome\"}, \"type\": \"HEADER\"}, \"ROOT_ID\": {\"children\": [\"GRID_ID\"], \"id\": \"ROOT_ID\", \"type\": \"ROOT\"}, \"ROW-1GPxzaxRVl\": {\"children\": [\"CHART-QDR6YSJs6l\"], \"id\": \"ROW-1GPxzaxRVl\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-FUc3gUSTRO\", \"COLUMN-p2tfT8G0yH\"], \"type\": \"ROW\"}, \"ROW-1wdi8YWyo3\": {\"children\": [\"CHART-VqMYjcjbwC\"], \"id\": \"ROW-1wdi8YWyo3\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}, \"ROW-FUc3gUSTRO\": {\"children\": [\"COLUMN-p2tfT8G0yH\", \"COLUMN-CVmDdXys5d\", \"COLUMN-vJhcpSQ1z2\"], \"id\": \"ROW-FUc3gUSTRO\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}, \"ROW-Orpw09D1Xl\": {\"children\": [\"COLUMN-J334JJKtC8\", \"CHART-sQVAlEKKA4\"], \"id\": \"ROW-Orpw09D1Xl\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}, \"ROW-_9fTlWqXxA\": {\"children\": [\"CHART-hbx1LJ_mGN\"], \"id\": \"ROW-_9fTlWqXxA\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}, \"ROW-eiNNHXGrgs\": {\"children\": [\"CHART-DKXi5_xppH\", \"COLUMN-KMn1AWkAZw\"], \"id\": \"ROW-eiNNHXGrgs\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}, \"ROW-gM6bL4qyS2\": {\"children\": [\"CHART-khRv3WBU_V\"], \"id\": \"ROW-gM6bL4qyS2\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}, \"ROW-hD1w3jICYS\": {\"children\": [\"CHART-AP66HrubVI\", \"CHART-041PHv_MRw\"], \"id\": \"ROW-hD1w3jICYS\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}, \"ROW-r-ExXo7qLY\": {\"children\": [\"CHART-6u-O9zaawH\"], \"id\": \"ROW-r-ExXo7qLY\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-FUc3gUSTRO\", \"COLUMN-vJhcpSQ1z2\"], \"type\": \"ROW\"}, \"ROW-xpq95QSNi8\": {\"children\": [\"COLUMN-WUmLX2QcTv\"], \"id\": \"ROW-xpq95QSNi8\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}, \"ROW-ynQWyCPKih\": {\"children\": [\"CHART-IRl6a81IDe\", \"CHART-g3HfBmugbt\"], \"id\": \"ROW-ynQWyCPKih\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}, \"ROW-zEiM4-hrfS\": {\"children\": [\"COLUMN-G9CulBOXBg\", \"CHART-SdGfHCf4OM\"], \"id\": \"ROW-zEiM4-hrfS\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}}",
+        "id": 1,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:40"
+        },
+        "created_by_fk": null,
+        "json_metadata": "{\"filter_immune_slices\": [], \"timed_refresh_immune_slices\": [], \"filter_immune_slice_fields\": {}, \"expanded_slices\": {}, \"default_filters\": \"{}\", \"remote_id\": 1, \"import_time\": 1560871295, \"refresh_frequency\": 0}",
+        "description": null,
+        "dashboard_title": "Welcome",
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:40"
+        },
+        "changed_by_fk": null,
+        "slug": null,
+        "css": "",
+        "slices": [
+          {
+            "__Slice__": {
+              "id": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:39"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "big_number_total",
+              "datasource_type": "table",
+              "slice_name": "Repository Count",
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:39"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[gitbase.repositories](id:10)",
+              "params": "{\"adhoc_filters\": [], \"datasource\": \"10__table\", \"granularity_sqla\": null, \"metric\": \"count\", \"slice_id\": 2, \"time_grain_sqla\": \"P1D\", \"time_range\": \"Last week\", \"url_params\": {}, \"viz_type\": \"big_number_total\", \"y_axis_format\": \".1s\", \"remote_id\": 1, \"datasource_name\": \"gitbase.repositories\", \"schema\": \"gitbase.repositories\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "gitbase.repositories",
+              "datasource_id": 10,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 2,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:39"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "area",
+              "datasource_type": "table",
+              "slice_name": "Commits Evolution",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:00"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-commit_merges-8X2HBrQre](id:20)",
+              "params": "{\"adhoc_filters\": [], \"annotation_layers\": [], \"bottom_margin\": \"auto\", \"color_scheme\": \"bnbColors\", \"comparison_type\": \"values\", \"contribution\": false, \"datasource\": \"14__table\", \"granularity_sqla\": \"commit_author_when\", \"groupby\": [\"commit_type\"], \"line_interpolation\": \"linear\", \"metrics\": [{\"aggregate\": null, \"column\": null, \"expressionType\": \"SQL\", \"fromFormData\": true, \"hasCustomLabel\": false, \"label\": \"COUNT(*)\", \"optionName\": \"metric_n4xn9emh55_60hid92bszp\", \"sqlExpression\": \"COUNT(*)\"}], \"order_desc\": true, \"resample_fillmethod\": null, \"resample_how\": null, \"resample_rule\": null, \"rich_tooltip\": true, \"rolling_type\": \"None\", \"row_limit\": 50000, \"show_brush\": \"auto\", \"show_controls\": false, \"show_legend\": true, \"slice_id\": 4, \"stacked_style\": \"stack\", \"time_grain_sqla\": \"P1M\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"area\", \"x_axis_format\": \"smart_date\", \"x_axis_label\": \"\", \"x_axis_showminmax\": false, \"x_ticks_layout\": \"auto\", \"y_axis_bounds\": [null, null], \"y_axis_format\": \".3s\", \"y_log_scale\": false, \"remote_id\": 2, \"datasource_name\": \"gitbase.admin admin-commit_merges-8X2HBrQre\", \"schema\": \"gitbase.admin admin-commit_merges-8X2HBrQre\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "gitbase.admin admin-commit_merges-8X2HBrQre",
+              "datasource_id": 20,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 3,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:39"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "table",
+              "datasource_type": "table",
+              "slice_name": "Repositories by number of files",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:00"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-repo_files_count-XXcl9_d2Y](id:12)",
+              "params": "{\"adhoc_filters\": [], \"align_pn\": false, \"all_columns\": [\"repository_id\", \"files_count\"], \"color_pn\": true, \"datasource\": \"15__table\", \"granularity_sqla\": null, \"groupby\": [], \"include_search\": false, \"include_time\": false, \"metrics\": [], \"order_by_cols\": [], \"order_desc\": true, \"page_length\": 0, \"percent_metrics\": [], \"row_limit\": 10000, \"slice_id\": 5, \"table_filter\": false, \"table_timestamp_format\": \"%Y-%m-%d %H:%M:%S\", \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"table\", \"remote_id\": 3, \"datasource_name\": \"gitbase.admin admin-repo_files_count-XXcl9_d2Y\", \"schema\": \"gitbase.admin admin-repo_files_count-XXcl9_d2Y\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "gitbase.admin admin-repo_files_count-XXcl9_d2Y",
+              "datasource_id": 12,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 4,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:39"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "dist_bar",
+              "datasource_type": "table",
+              "slice_name": "Number of commits per day of the week",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-commits_per_day-lGJ1u0Kbm](id:15)",
+              "params": "{\"adhoc_filters\": [], \"bar_stacked\": true, \"bottom_margin\": \"auto\", \"color_scheme\": \"bnbColors\", \"columns\": [\"commit_type\"], \"contribution\": false, \"datasource\": \"16__table\", \"granularity_sqla\": null, \"groupby\": [\"day\"], \"metrics\": [\"count\"], \"order_bars\": true, \"reduce_x_ticks\": false, \"row_limit\": 50000, \"show_bar_value\": true, \"show_controls\": false, \"show_legend\": true, \"slice_id\": 6, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"dist_bar\", \"x_axis_label\": \"Day of the week\", \"x_ticks_layout\": \"auto\", \"y_axis_format\": \".3s\", \"y_axis_label\": \"Number of imports\", \"remote_id\": 4, \"datasource_name\": \"gitbase.admin admin-commits_per_day-lGJ1u0Kbm\", \"schema\": \"gitbase.admin admin-commits_per_day-lGJ1u0Kbm\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "gitbase.admin admin-commits_per_day-lGJ1u0Kbm",
+              "datasource_id": 15,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 5,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:39"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "big_number_total",
+              "datasource_type": "table",
+              "slice_name": "Compliance score",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-compliance_score-ReDkKHp6n](id:28)",
+              "params": "{\"adhoc_filters\": [], \"datasource\": \"17__table\", \"granularity_sqla\": null, \"metric\": \"compliance\", \"slice_id\": 7, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"big_number_total\", \"y_axis_format\": \",.1%\", \"remote_id\": 5, \"datasource_name\": \"gitbase.admin admin-compliance_score-ReDkKHp6n\", \"schema\": \"gitbase.admin admin-compliance_score-ReDkKHp6n\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "gitbase.admin admin-compliance_score-ReDkKHp6n",
+              "datasource_id": 28,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 6,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:39"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "table",
+              "datasource_type": "table",
+              "slice_name": "Missing files",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-missing_files-Y0yDW8RN6](id:23)",
+              "params": "{\"adhoc_filters\": [], \"align_pn\": false, \"all_columns\": [\"repository_id\", \"changelog\", \"readme\", \"notice\", \"license\", \"contributing\", \"travis\", \"ci\", \"dockerfile\"], \"color_pn\": true, \"datasource\": \"18__table\", \"granularity_sqla\": null, \"groupby\": [], \"include_search\": false, \"include_time\": false, \"metrics\": [], \"order_by_cols\": [], \"order_desc\": true, \"page_length\": 0, \"percent_metrics\": [], \"row_limit\": 10000, \"slice_id\": 8, \"table_filter\": false, \"table_timestamp_format\": \"%Y-%m-%d %H:%M:%S\", \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"table\", \"remote_id\": 6, \"datasource_name\": \"gitbase.admin admin-missing_files-Y0yDW8RN6\", \"schema\": \"gitbase.admin admin-missing_files-Y0yDW8RN6\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "gitbase.admin admin-missing_files-Y0yDW8RN6",
+              "datasource_id": 23,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 7,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:40"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "table",
+              "datasource_type": "table",
+              "slice_name": "Files missing summary",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-missing_files_summary-YqNVbLHqJ](id:25)",
+              "params": "{\"adhoc_filters\": [], \"align_pn\": false, \"all_columns\": [\"changelog\", \"readme\", \"notice\", \"license\", \"contributing\", \"travis\", \"ci\", \"dockerfile\"], \"color_pn\": true, \"datasource\": \"19__table\", \"granularity_sqla\": null, \"groupby\": [], \"include_search\": false, \"include_time\": false, \"metrics\": [], \"order_by_cols\": [], \"order_desc\": true, \"page_length\": 0, \"percent_metrics\": [], \"row_limit\": 1000, \"slice_id\": 9, \"table_filter\": false, \"table_timestamp_format\": \"%Y-%m-%d %H:%M:%S\", \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"table\", \"remote_id\": 7, \"datasource_name\": \"gitbase.admin admin-missing_files_summary-YqNVbLHqJ\", \"schema\": \"gitbase.admin admin-missing_files_summary-YqNVbLHqJ\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "gitbase.admin admin-missing_files_summary-YqNVbLHqJ",
+              "datasource_id": 25,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 8,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:40"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "big_number_total",
+              "datasource_type": "table",
+              "slice_name": "Number of collaborators",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-Untitled Query-mW48VqXdL](id:14)",
+              "params": "{\"adhoc_filters\": [], \"datasource\": \"19__table\", \"granularity_sqla\": null, \"metric\": \"count\", \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"big_number_total\", \"y_axis_format\": null, \"remote_id\": 8, \"datasource_name\": \"admin admin-Untitled Query-mW48VqXdL\", \"schema\": \"admin admin-Untitled Query-mW48VqXdL\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "admin admin-Untitled Query-mW48VqXdL",
+              "datasource_id": 14,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 9,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:40"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "bar",
+              "datasource_type": "table",
+              "slice_name": "Number of releases per month and repository",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-Untitled Query-LUNdDHhhu](id:24)",
+              "params": "{\"adhoc_filters\": [], \"annotation_layers\": [], \"bar_stacked\": false, \"bottom_margin\": \"auto\", \"color_scheme\": \"SUPERSET_DEFAULT\", \"comparison_type\": \"values\", \"contribution\": false, \"datasource\": \"20__table\", \"granularity_sqla\": \"date\", \"groupby\": [\"repository_id\"], \"left_margin\": \"auto\", \"line_interpolation\": \"linear\", \"metrics\": [{\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 91, \"is_dttm\": false, \"python_date_format\": null, \"type\": \"LONGLONG\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": true, \"hasCustomLabel\": false, \"label\": \"MAX(n)\", \"optionName\": \"metric_cku1kelnng4_lvhjyhmek5\", \"sqlExpression\": null}], \"order_desc\": true, \"reduce_x_ticks\": false, \"resample_fillmethod\": null, \"resample_how\": null, \"resample_rule\": null, \"rich_tooltip\": true, \"rolling_type\": \"None\", \"row_limit\": 1000, \"show_bar_value\": false, \"show_brush\": \"auto\", \"show_controls\": false, \"show_legend\": true, \"slice_id\": 11, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"bar\", \"x_axis_format\": \"smart_date\", \"x_axis_label\": \"\", \"x_axis_showminmax\": false, \"x_ticks_layout\": \"auto\", \"y_axis_bounds\": [null, null], \"y_axis_format\": null, \"y_axis_label\": \"\", \"y_axis_showminmax\": false, \"y_log_scale\": false, \"remote_id\": 9, \"datasource_name\": \"null.admin admin-Untitled Query-LUNdDHhhu\", \"schema\": \"null.admin admin-Untitled Query-LUNdDHhhu\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "null.admin admin-Untitled Query-LUNdDHhhu",
+              "datasource_id": 24,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 10,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:40"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "bar",
+              "datasource_type": "table",
+              "slice_name": "Number of commits to HEAD per month",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-Untitled Query-0scA3HaD5](id:18)",
+              "params": "{\"adhoc_filters\": [], \"annotation_layers\": [], \"bar_stacked\": true, \"bottom_margin\": \"auto\", \"color_scheme\": \"d3Category10\", \"comparison_type\": \"values\", \"contribution\": false, \"datasource\": \"21__table\", \"granularity_sqla\": \"commit_author_when\", \"groupby\": [], \"left_margin\": \"auto\", \"line_interpolation\": \"linear\", \"metrics\": [\"count\"], \"order_desc\": true, \"reduce_x_ticks\": false, \"resample_fillmethod\": null, \"resample_how\": null, \"resample_rule\": null, \"rich_tooltip\": true, \"rolling_type\": \"None\", \"row_limit\": 1000, \"show_bar_value\": false, \"show_brush\": \"auto\", \"show_controls\": false, \"show_legend\": false, \"slice_id\": 12, \"time_grain_sqla\": \"P1M\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"url_params\": {}, \"viz_type\": \"bar\", \"x_axis_format\": \"smart_date\", \"x_axis_label\": \"\", \"x_axis_showminmax\": false, \"x_ticks_layout\": \"auto\", \"y_axis_bounds\": [null, null], \"y_axis_format\": \".3s\", \"y_axis_label\": \"\", \"y_axis_showminmax\": false, \"y_log_scale\": false, \"remote_id\": 10, \"datasource_name\": \"null.admin admin-Untitled Query-0scA3HaD5\", \"schema\": \"null.admin admin-Untitled Query-0scA3HaD5\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "null.admin admin-Untitled Query-0scA3HaD5",
+              "datasource_id": 18,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 11,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:40"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "bar",
+              "datasource_type": "table",
+              "slice_name": "Number of commits per month breakdown per repo",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-Untitled Query-Wfqa9oVcQ](id:27)",
+              "params": "{\"adhoc_filters\": [], \"annotation_layers\": [], \"bar_stacked\": true, \"bottom_margin\": \"auto\", \"color_scheme\": \"SUPERSET_DEFAULT\", \"comparison_type\": \"values\", \"contribution\": false, \"datasource\": \"22__table\", \"granularity_sqla\": \"commit_date\", \"groupby\": [\"repo\"], \"left_margin\": \"auto\", \"line_interpolation\": \"linear\", \"metrics\": [\"count\"], \"order_desc\": true, \"reduce_x_ticks\": true, \"resample_fillmethod\": null, \"resample_how\": null, \"resample_rule\": null, \"rich_tooltip\": true, \"rolling_type\": \"None\", \"row_limit\": 1000, \"show_bar_value\": false, \"show_brush\": \"no\", \"show_controls\": false, \"show_legend\": true, \"slice_id\": 13, \"time_grain_sqla\": \"P1M\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"url_params\": {}, \"viz_type\": \"bar\", \"x_axis_format\": \"smart_date\", \"x_axis_label\": \"\", \"x_axis_showminmax\": false, \"x_ticks_layout\": \"auto\", \"y_axis_bounds\": [null, null], \"y_axis_format\": \".3s\", \"y_axis_label\": \"\", \"y_axis_showminmax\": false, \"y_log_scale\": false, \"remote_id\": 11, \"datasource_name\": \"null.admin admin-Untitled Query-Wfqa9oVcQ\", \"schema\": \"null.admin admin-Untitled Query-Wfqa9oVcQ\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "null.admin admin-Untitled Query-Wfqa9oVcQ",
+              "datasource_id": 27,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 12,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:40"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "dist_bar",
+              "datasource_type": "table",
+              "slice_name": "Total number of commits per repository",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-Untitled Query-rpq4L7GFr](id:17)",
+              "params": "{\"adhoc_filters\": [], \"bar_stacked\": false, \"bottom_margin\": 100, \"color_scheme\": \"SUPERSET_DEFAULT\", \"columns\": [], \"contribution\": false, \"datasource\": \"23__table\", \"granularity_sqla\": null, \"groupby\": [\"repository_id\"], \"metrics\": [{\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 98, \"is_dttm\": false, \"python_date_format\": null, \"type\": \"LONGLONG\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": true, \"hasCustomLabel\": false, \"label\": \"MAX(n)\", \"optionName\": \"metric_ozqrfezkw4o_zf5mkt49ns\", \"sqlExpression\": null}], \"order_bars\": false, \"reduce_x_ticks\": false, \"row_limit\": 1000, \"show_bar_value\": false, \"show_controls\": false, \"show_legend\": false, \"slice_id\": 14, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"url_params\": {}, \"viz_type\": \"dist_bar\", \"x_axis_label\": \"\", \"x_ticks_layout\": \"staggered\", \"y_axis_format\": null, \"y_axis_label\": \"\", \"remote_id\": 12, \"datasource_name\": \"null.admin admin-Untitled Query-rpq4L7GFr\", \"schema\": \"null.admin admin-Untitled Query-rpq4L7GFr\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "null.admin admin-Untitled Query-rpq4L7GFr",
+              "datasource_id": 17,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 13,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:40"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "pie",
+              "datasource_type": "table",
+              "slice_name": "Number of files per languages",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-Untitled Query-Kmw5frZ_b](id:16)",
+              "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"24__table\", \"donut\": false, \"granularity_sqla\": null, \"groupby\": [\"lang\"], \"labels_outside\": true, \"metric\": {\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 100, \"is_dttm\": false, \"optionName\": \"_col_n\", \"python_date_format\": null, \"type\": \"LONGLONG\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": true, \"hasCustomLabel\": false, \"label\": \"MAX(n)\", \"optionName\": \"metric_fgo2qfox5ct_76gkjbqjn0l\", \"sqlExpression\": null}, \"number_format\": \".3s\", \"pie_label_type\": \"key\", \"row_limit\": 1000, \"show_labels\": true, \"show_legend\": false, \"slice_id\": 15, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"url_params\": {}, \"viz_type\": \"pie\", \"remote_id\": 13, \"datasource_name\": \"null.admin admin-Untitled Query-Kmw5frZ_b\", \"schema\": \"null.admin admin-Untitled Query-Kmw5frZ_b\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "null.admin admin-Untitled Query-Kmw5frZ_b",
+              "datasource_id": 16,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 14,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:40"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "pie",
+              "datasource_type": "table",
+              "slice_name": "Number of lines of code per language",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-Untitled Query-ykYJeoJJn](id:19)",
+              "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"26__table\", \"donut\": false, \"granularity_sqla\": null, \"groupby\": [\"lang\"], \"labels_outside\": true, \"metric\": {\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"sum_n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 104, \"is_dttm\": false, \"python_date_format\": null, \"type\": \"DOUBLE\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": true, \"hasCustomLabel\": false, \"label\": \"MAX(sum_n)\", \"optionName\": \"metric_9rbc46c8jz5_19sstwscubq\", \"sqlExpression\": null}, \"number_format\": \".3s\", \"pie_label_type\": \"key\", \"row_limit\": 1000, \"show_labels\": true, \"show_legend\": false, \"slice_id\": 17, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"pie\", \"remote_id\": 14, \"datasource_name\": \"null.admin admin-Untitled Query-ykYJeoJJn\", \"schema\": \"null.admin admin-Untitled Query-ykYJeoJJn\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "null.admin admin-Untitled Query-ykYJeoJJn",
+              "datasource_id": 19,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 15,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:40"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "pie",
+              "datasource_type": "table",
+              "slice_name": "Number of contributions per organization",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-Untitled Query-tEO1Ih2Uu](id:29)",
+              "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"27__table\", \"donut\": false, \"granularity_sqla\": null, \"groupby\": [\"domain\"], \"labels_outside\": true, \"metric\": {\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 106, \"is_dttm\": false, \"optionName\": \"_col_n\", \"python_date_format\": null, \"type\": \"LONGLONG\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": false, \"hasCustomLabel\": false, \"label\": \"MAX(n)\", \"optionName\": \"metric_g4rpo9wf9ew_ujjshbhz88\", \"sqlExpression\": null}, \"number_format\": \".3s\", \"pie_label_type\": \"key\", \"row_limit\": 1000, \"show_labels\": true, \"show_legend\": false, \"slice_id\": 18, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"url_params\": {}, \"viz_type\": \"pie\", \"remote_id\": 15, \"datasource_name\": \"null.admin admin-Untitled Query-tEO1Ih2Uu\", \"schema\": \"null.admin admin-Untitled Query-tEO1Ih2Uu\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "null.admin admin-Untitled Query-tEO1Ih2Uu",
+              "datasource_id": 29,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 16,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:40"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "word_cloud",
+              "datasource_type": "table",
+              "slice_name": "Organization wordcloud",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-Untitled Query-UnJl1GKQ8](id:13)",
+              "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"29__table\", \"granularity_sqla\": null, \"metric\": {\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 110, \"is_dttm\": false, \"optionName\": \"_col_n\", \"python_date_format\": null, \"type\": \"LONGLONG\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": false, \"hasCustomLabel\": false, \"label\": \"MAX(n)\", \"optionName\": \"metric_1yxqanppn5b_vz0jq5if73j\", \"sqlExpression\": null}, \"rotation\": \"square\", \"row_limit\": 250, \"series\": \"domain\", \"size_from\": 18, \"size_to\": 70, \"slice_id\": 19, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"url_params\": {}, \"viz_type\": \"word_cloud\", \"remote_id\": 16, \"datasource_name\": \"null.admin admin-Untitled Query-UnJl1GKQ8\", \"schema\": \"null.admin admin-Untitled Query-UnJl1GKQ8\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "null.admin admin-Untitled Query-UnJl1GKQ8",
+              "datasource_id": 13,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 17,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:40"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "pie",
+              "datasource_type": "table",
+              "slice_name": "Number of contributions per email",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-Untitled Query-boJAIGUPS](id:22)",
+              "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"30__table\", \"donut\": false, \"granularity_sqla\": null, \"groupby\": [\"committer_email\"], \"labels_outside\": true, \"metric\": {\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 112, \"is_dttm\": false, \"optionName\": \"_col_n\", \"python_date_format\": null, \"type\": \"LONGLONG\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": false, \"hasCustomLabel\": false, \"label\": \"MAX(n)\", \"optionName\": \"metric_ph1p73w244_tswjzepbscl\", \"sqlExpression\": null}, \"number_format\": \".3s\", \"pie_label_type\": \"key\", \"row_limit\": 1000, \"show_labels\": true, \"show_legend\": false, \"slice_id\": 20, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"url_params\": {}, \"viz_type\": \"pie\", \"remote_id\": 17, \"datasource_name\": \"null.admin admin-Untitled Query-boJAIGUPS\", \"schema\": \"null.admin admin-Untitled Query-boJAIGUPS\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "null.admin admin-Untitled Query-boJAIGUPS",
+              "datasource_id": 22,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 18,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:40"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "word_cloud",
+              "datasource_type": "table",
+              "slice_name": "Email wordcloud",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-Untitled Query-JJ5b9O0Hc](id:30)",
+              "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"32__table\", \"granularity_sqla\": null, \"metric\": {\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 116, \"is_dttm\": false, \"optionName\": \"_col_n\", \"python_date_format\": null, \"type\": \"LONGLONG\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": false, \"hasCustomLabel\": false, \"label\": \"MAX(n)\", \"optionName\": \"metric_ajg1mqrbzth_tmqjky93xdc\", \"sqlExpression\": null}, \"rotation\": \"square\", \"row_limit\": 1000, \"series\": \"committer_email\", \"size_from\": 16, \"size_to\": 50, \"slice_id\": 21, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"url_params\": {}, \"viz_type\": \"word_cloud\", \"remote_id\": 18, \"datasource_name\": \"null.admin admin-Untitled Query-JJ5b9O0Hc\", \"schema\": \"null.admin admin-Untitled Query-JJ5b9O0Hc\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "null.admin admin-Untitled Query-JJ5b9O0Hc",
+              "datasource_id": 30,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 19,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:40"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "table",
+              "datasource_type": "table",
+              "slice_name": "Repository by number of collaborators",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-Untitled Query-CmGNVca6-](id:26)",
+              "params": "{\"adhoc_filters\": [], \"align_pn\": false, \"all_columns\": [\"repository_id\", \"collaborators_count\"], \"color_pn\": true, \"datasource\": \"33__table\", \"granularity_sqla\": null, \"groupby\": [], \"include_search\": false, \"include_time\": false, \"metrics\": [], \"order_by_cols\": [], \"order_desc\": true, \"page_length\": 0, \"percent_metrics\": [], \"row_limit\": 1000, \"slice_id\": 22, \"table_filter\": false, \"table_timestamp_format\": \"%Y-%m-%d %H:%M:%S\", \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"table\", \"remote_id\": 19, \"datasource_name\": \"null.admin admin-Untitled Query-CmGNVca6-\", \"schema\": \"null.admin admin-Untitled Query-CmGNVca6-\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "null.admin admin-Untitled Query-CmGNVca6-",
+              "datasource_id": 26,
+              "owners": []
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 20,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:40"
+              },
+              "created_by_fk": null,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "pie",
+              "datasource_type": "table",
+              "slice_name": "Languages",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[gitbase].[admin admin-head_repo_languages-FJfWO1kQ4](id:21)",
+              "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"15__table\", \"donut\": true, \"granularity_sqla\": null, \"groupby\": [\"lang\"], \"labels_outside\": false, \"metric\": \"count\", \"number_format\": \".3s\", \"pie_label_type\": \"key\", \"row_limit\": 1000, \"show_labels\": true, \"show_legend\": false, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"pie\", \"remote_id\": 20, \"datasource_name\": \"gitbase.admin admin-head_repo_languages-FJfWO1kQ4\", \"schema\": \"gitbase.admin admin-head_repo_languages-FJfWO1kQ4\", \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+              "datasource_name": "gitbase.admin admin-head_repo_languages-FJfWO1kQ4",
+              "datasource_id": 21,
+              "owners": []
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "datasources": [
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "gitbase",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:35"
+        },
+        "sql": "SELECT\r\n    repo,\r\n    CASE\r\n        WHEN day_index = 2 THEN '1 - Monday'\r\n        WHEN day_index = 3 THEN '2 - Tuesday'\r\n        WHEN day_index = 4 THEN '3 - Wednesday'\r\n        WHEN day_index = 5 THEN '4 - Thursday'\r\n        WHEN day_index = 6 THEN '5 - Friday'\r\n        WHEN day_index = 7 THEN '6 - Saturday'\r\n        ELSE '7 - Sunday'\r\n    END AS day,\r\n    CASE\r\n        WHEN n_parents > 1 THEN 'Merge commit'\r\n        ELSE 'Non-merge commit'\r\n    END AS commit_type\r\nFROM (\r\n    SELECT\r\n        repository_id AS repo,\r\n        DAYOFWEEK(committer_when) AS day_index,\r\n        ARRAY_LENGTH(commit_parents) AS n_parents\r\n    FROM commits\r\n) t",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:35"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 15, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 15,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-commits_per_day-lGJ1u0Kbm](id:15)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-commits_per_day-lGJ1u0Kbm",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 15,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "column_name": "repo",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 58,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 15,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "column_name": "day",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 59,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 15,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "column_name": "commit_type",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 60,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "id": 15,
+              "created_by_fk": null,
+              "table_id": 15,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
             "changed_on": {
-                "__datetime__": "2019-06-14T13:44:32"
+              "__datetime__": "2019-06-18T15:21:06"
             },
-            "changed_by_fk": 1,
-            "slug": null,
-            "slices": [{
-                    "__Slice__": {
-                        "datasource_id": 10,
-                        "id": 1,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:16:06"
-                        },
-                        "created_by_fk": null,
-                        "perm": "[gitbase].[gitbase.repositories](id:10)",
-                        "description": null,
-                        "viz_type": "big_number_total",
-                        "datasource_type": "table",
-                        "slice_name": "Repository Count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"datasource\": \"10__table\", \"granularity_sqla\": null, \"metric\": \"count\", \"slice_id\": 2, \"time_grain_sqla\": \"P1D\", \"time_range\": \"Last week\", \"url_params\": {}, \"viz_type\": \"big_number_total\", \"y_axis_format\": \".1s\", \"remote_id\": 1, \"datasource_name\": \"gitbase.repositories\", \"schema\": \"gitbase.repositories\", \"database_name\": \"gitbase\", \"import_time\": 1560421533}",
-                        "datasource_name": "gitbase.repositories",
-                        "owners": []
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 16,
-                        "id": 3,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[gitbase].[admin admin-commit_merges-8X2HBrQre](id:16)",
-                        "description": null,
-                        "viz_type": "area",
-                        "datasource_type": "table",
-                        "slice_name": "Commits Evolution",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"annotation_layers\": [], \"bottom_margin\": \"auto\", \"color_scheme\": \"bnbColors\", \"comparison_type\": \"values\", \"contribution\": false, \"datasource\": \"14__table\", \"granularity_sqla\": \"commit_author_when\", \"groupby\": [\"commit_type\"], \"line_interpolation\": \"linear\", \"metrics\": [{\"aggregate\": null, \"column\": null, \"expressionType\": \"SQL\", \"fromFormData\": true, \"hasCustomLabel\": false, \"label\": \"COUNT(*)\", \"optionName\": \"metric_n4xn9emh55_60hid92bszp\", \"sqlExpression\": \"COUNT(*)\"}], \"order_desc\": true, \"resample_fillmethod\": null, \"resample_how\": null, \"resample_rule\": null, \"rich_tooltip\": true, \"rolling_type\": \"None\", \"row_limit\": 50000, \"show_brush\": \"auto\", \"show_controls\": false, \"show_legend\": true, \"slice_id\": 4, \"stacked_style\": \"stack\", \"time_grain_sqla\": \"P1M\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"area\", \"x_axis_format\": \"smart_date\", \"x_axis_label\": \"\", \"x_axis_showminmax\": false, \"x_ticks_layout\": \"auto\", \"y_axis_bounds\": [null, null], \"y_axis_format\": \".3s\", \"y_log_scale\": false, \"remote_id\": 3, \"datasource_name\": \"gitbase.admin admin-commit_merges-8X2HBrQre\", \"schema\": \"gitbase.admin admin-commit_merges-8X2HBrQre\", \"database_name\": \"gitbase\", \"import_time\": 1560421533}",
-                        "datasource_name": "gitbase.admin admin-commit_merges-8X2HBrQre",
-                        "owners": []
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 14,
-                        "id": 4,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[gitbase].[admin admin-repo_files_count-XXcl9_d2Y](id:14)",
-                        "description": null,
-                        "viz_type": "table",
-                        "datasource_type": "table",
-                        "slice_name": "Repositories by number of files",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"align_pn\": false, \"all_columns\": [\"repository_id\", \"files_count\"], \"color_pn\": true, \"datasource\": \"15__table\", \"granularity_sqla\": null, \"groupby\": [], \"include_search\": false, \"include_time\": false, \"metrics\": [], \"order_by_cols\": [], \"order_desc\": true, \"page_length\": 0, \"percent_metrics\": [], \"row_limit\": 10000, \"slice_id\": 5, \"table_filter\": false, \"table_timestamp_format\": \"%Y-%m-%d %H:%M:%S\", \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"table\", \"remote_id\": 4, \"datasource_name\": \"gitbase.admin admin-repo_files_count-XXcl9_d2Y\", \"schema\": \"gitbase.admin admin-repo_files_count-XXcl9_d2Y\", \"database_name\": \"gitbase\", \"import_time\": 1560421533}",
-                        "datasource_name": "gitbase.admin admin-repo_files_count-XXcl9_d2Y",
-                        "owners": []
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 17,
-                        "id": 5,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[gitbase].[admin admin-commits_per_day-lGJ1u0Kbm](id:17)",
-                        "description": null,
-                        "viz_type": "dist_bar",
-                        "datasource_type": "table",
-                        "slice_name": "Number of commits per day of the week",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"bar_stacked\": true, \"bottom_margin\": \"auto\", \"color_scheme\": \"bnbColors\", \"columns\": [\"commit_type\"], \"contribution\": false, \"datasource\": \"16__table\", \"granularity_sqla\": null, \"groupby\": [\"day\"], \"metrics\": [\"count\"], \"order_bars\": true, \"reduce_x_ticks\": false, \"row_limit\": 50000, \"show_bar_value\": true, \"show_controls\": false, \"show_legend\": true, \"slice_id\": 6, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"dist_bar\", \"x_axis_label\": \"Day of the week\", \"x_ticks_layout\": \"auto\", \"y_axis_format\": \".3s\", \"y_axis_label\": \"Number of imports\", \"remote_id\": 5, \"datasource_name\": \"gitbase.admin admin-commits_per_day-lGJ1u0Kbm\", \"schema\": \"gitbase.admin admin-commits_per_day-lGJ1u0Kbm\", \"database_name\": \"gitbase\", \"import_time\": 1560421533}",
-                        "datasource_name": "gitbase.admin admin-commits_per_day-lGJ1u0Kbm",
-                        "owners": []
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 12,
-                        "id": 6,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[gitbase].[admin admin-compliance_score-ReDkKHp6n](id:12)",
-                        "description": null,
-                        "viz_type": "big_number_total",
-                        "datasource_type": "table",
-                        "slice_name": "Compliance score",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"datasource\": \"17__table\", \"granularity_sqla\": null, \"metric\": \"compliance\", \"slice_id\": 7, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"big_number_total\", \"y_axis_format\": \",.1%\", \"remote_id\": 6, \"datasource_name\": \"gitbase.admin admin-compliance_score-ReDkKHp6n\", \"schema\": \"gitbase.admin admin-compliance_score-ReDkKHp6n\", \"database_name\": \"gitbase\", \"import_time\": 1560421533}",
-                        "datasource_name": "gitbase.admin admin-compliance_score-ReDkKHp6n",
-                        "owners": []
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 13,
-                        "id": 7,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[gitbase].[admin admin-missing_files-Y0yDW8RN6](id:13)",
-                        "description": null,
-                        "viz_type": "table",
-                        "datasource_type": "table",
-                        "slice_name": "Missing files",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"align_pn\": false, \"all_columns\": [\"repository_id\", \"changelog\", \"readme\", \"notice\", \"license\", \"contributing\", \"travis\", \"ci\", \"dockerfile\"], \"color_pn\": true, \"datasource\": \"18__table\", \"granularity_sqla\": null, \"groupby\": [], \"include_search\": false, \"include_time\": false, \"metrics\": [], \"order_by_cols\": [], \"order_desc\": true, \"page_length\": 0, \"percent_metrics\": [], \"row_limit\": 10000, \"slice_id\": 8, \"table_filter\": false, \"table_timestamp_format\": \"%Y-%m-%d %H:%M:%S\", \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"table\", \"remote_id\": 7, \"datasource_name\": \"gitbase.admin admin-missing_files-Y0yDW8RN6\", \"schema\": \"gitbase.admin admin-missing_files-Y0yDW8RN6\", \"database_name\": \"gitbase\", \"import_time\": 1560421533}",
-                        "datasource_name": "gitbase.admin admin-missing_files-Y0yDW8RN6",
-                        "owners": []
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 18,
-                        "id": 8,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[gitbase].[admin admin-missing_files_summary-YqNVbLHqJ](id:18)",
-                        "description": null,
-                        "viz_type": "table",
-                        "datasource_type": "table",
-                        "slice_name": "Files missing summary",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"align_pn\": false, \"all_columns\": [\"changelog\", \"readme\", \"notice\", \"license\", \"contributing\", \"travis\", \"ci\", \"dockerfile\"], \"color_pn\": true, \"datasource\": \"19__table\", \"granularity_sqla\": null, \"groupby\": [], \"include_search\": false, \"include_time\": false, \"metrics\": [], \"order_by_cols\": [], \"order_desc\": true, \"page_length\": 0, \"percent_metrics\": [], \"row_limit\": 1000, \"slice_id\": 9, \"table_filter\": false, \"table_timestamp_format\": \"%Y-%m-%d %H:%M:%S\", \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"table\", \"remote_id\": 8, \"datasource_name\": \"gitbase.admin admin-missing_files_summary-YqNVbLHqJ\", \"schema\": \"gitbase.admin admin-missing_files_summary-YqNVbLHqJ\", \"database_name\": \"gitbase\", \"import_time\": 1560421533}",
-                        "datasource_name": "gitbase.admin admin-missing_files_summary-YqNVbLHqJ",
-                        "owners": []
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 19,
-                        "id": 10,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:45:13"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[None].[admin admin-Untitled Query-mW48VqXdL](id:19)",
-                        "description": null,
-                        "viz_type": "big_number_total",
-                        "datasource_type": "table",
-                        "slice_name": "Number of collaborators",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T15:46:33"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"datasource\": \"19__table\", \"granularity_sqla\": null, \"metric\": \"count\", \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"big_number_total\", \"y_axis_format\": null, \"remote_id\": 10, \"datasource_name\": \"admin admin-Untitled Query-mW48VqXdL\", \"schema\": \"admin admin-Untitled Query-mW48VqXdL\", \"database_name\": \"gitbase\"}",
-                        "datasource_name": "admin admin-Untitled Query-mW48VqXdL",
-                        "owners": [{
-                            "__User__": {
-                                "changed_by_fk": null,
-                                "active": true,
-                                "email": "admin@example.com",
-                                "last_login": {
-                                    "__datetime__": "2019-06-13T10:24:18"
-                                },
-                                "id": 1,
-                                "login_count": 1,
-                                "first_name": "admin",
-                                "fail_login_count": 0,
-                                "last_name": "admin",
-                                "created_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "username": "admin",
-                                "changed_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "password": "pbkdf2:sha256:50000$64PX8iD9$187fbff76d3f68e0f6b2df52054222556aac0ffab8b84616b0c92500239d2f2e",
-                                "created_by_fk": null
-                            }
-                        }]
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 20,
-                        "id": 11,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T13:44:47"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[None].[admin admin-Untitled Query-LUNdDHhhu](id:20)",
-                        "description": null,
-                        "viz_type": "bar",
-                        "datasource_type": "table",
-                        "slice_name": "Number of releases per month and repository",
-                        "changed_on": {
-                            "__datetime__": "2019-06-14T13:57:02"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"annotation_layers\": [], \"bar_stacked\": false, \"bottom_margin\": \"auto\", \"color_scheme\": \"SUPERSET_DEFAULT\", \"comparison_type\": \"values\", \"contribution\": false, \"datasource\": \"20__table\", \"granularity_sqla\": \"date\", \"groupby\": [\"repository_id\"], \"left_margin\": \"auto\", \"line_interpolation\": \"linear\", \"metrics\": [{\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 91, \"is_dttm\": false, \"python_date_format\": null, \"type\": \"LONGLONG\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": true, \"hasCustomLabel\": false, \"label\": \"MAX(n)\", \"optionName\": \"metric_cku1kelnng4_lvhjyhmek5\", \"sqlExpression\": null}], \"order_desc\": true, \"reduce_x_ticks\": false, \"resample_fillmethod\": null, \"resample_how\": null, \"resample_rule\": null, \"rich_tooltip\": true, \"rolling_type\": \"None\", \"row_limit\": 1000, \"show_bar_value\": false, \"show_brush\": \"auto\", \"show_controls\": false, \"show_legend\": true, \"slice_id\": 11, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"bar\", \"x_axis_format\": \"smart_date\", \"x_axis_label\": \"\", \"x_axis_showminmax\": false, \"x_ticks_layout\": \"auto\", \"y_axis_bounds\": [null, null], \"y_axis_format\": null, \"y_axis_label\": \"\", \"y_axis_showminmax\": false, \"y_log_scale\": false, \"remote_id\": 11, \"datasource_name\": \"null.admin admin-Untitled Query-LUNdDHhhu\", \"schema\": \"null.admin admin-Untitled Query-LUNdDHhhu\", \"database_name\": \"gitbase\"}",
-                        "datasource_name": "null.admin admin-Untitled Query-LUNdDHhhu",
-                        "owners": [{
-                            "__User__": {
-                                "changed_by_fk": null,
-                                "active": true,
-                                "email": "admin@example.com",
-                                "last_login": {
-                                    "__datetime__": "2019-06-13T10:24:18"
-                                },
-                                "id": 1,
-                                "login_count": 1,
-                                "first_name": "admin",
-                                "fail_login_count": 0,
-                                "last_name": "admin",
-                                "created_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "username": "admin",
-                                "changed_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "password": "pbkdf2:sha256:50000$64PX8iD9$187fbff76d3f68e0f6b2df52054222556aac0ffab8b84616b0c92500239d2f2e",
-                                "created_by_fk": null
-                            }
-                        }]
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 21,
-                        "id": 12,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T14:16:50"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[None].[admin admin-Untitled Query-0scA3HaD5](id:21)",
-                        "description": null,
-                        "viz_type": "bar",
-                        "datasource_type": "table",
-                        "slice_name": "Number of commits to HEAD per month",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T15:46:33"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"annotation_layers\": [], \"bar_stacked\": true, \"bottom_margin\": \"auto\", \"color_scheme\": \"d3Category10\", \"comparison_type\": \"values\", \"contribution\": false, \"datasource\": \"21__table\", \"granularity_sqla\": \"commit_author_when\", \"groupby\": [], \"left_margin\": \"auto\", \"line_interpolation\": \"linear\", \"metrics\": [\"count\"], \"order_desc\": true, \"reduce_x_ticks\": false, \"resample_fillmethod\": null, \"resample_how\": null, \"resample_rule\": null, \"rich_tooltip\": true, \"rolling_type\": \"None\", \"row_limit\": 1000, \"show_bar_value\": false, \"show_brush\": \"auto\", \"show_controls\": false, \"show_legend\": false, \"slice_id\": 12, \"time_grain_sqla\": \"P1M\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"url_params\": {}, \"viz_type\": \"bar\", \"x_axis_format\": \"smart_date\", \"x_axis_label\": \"\", \"x_axis_showminmax\": false, \"x_ticks_layout\": \"auto\", \"y_axis_bounds\": [null, null], \"y_axis_format\": \".3s\", \"y_axis_label\": \"\", \"y_axis_showminmax\": false, \"y_log_scale\": false, \"remote_id\": 12, \"datasource_name\": \"null.admin admin-Untitled Query-0scA3HaD5\", \"schema\": \"null.admin admin-Untitled Query-0scA3HaD5\", \"database_name\": \"gitbase\"}",
-                        "datasource_name": "null.admin admin-Untitled Query-0scA3HaD5",
-                        "owners": [{
-                            "__User__": {
-                                "changed_by_fk": null,
-                                "active": true,
-                                "email": "admin@example.com",
-                                "last_login": {
-                                    "__datetime__": "2019-06-13T10:24:18"
-                                },
-                                "id": 1,
-                                "login_count": 1,
-                                "first_name": "admin",
-                                "fail_login_count": 0,
-                                "last_name": "admin",
-                                "created_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "username": "admin",
-                                "changed_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "password": "pbkdf2:sha256:50000$64PX8iD9$187fbff76d3f68e0f6b2df52054222556aac0ffab8b84616b0c92500239d2f2e",
-                                "created_by_fk": null
-                            }
-                        }]
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 22,
-                        "id": 13,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T14:27:48"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[None].[admin admin-Untitled Query-Wfqa9oVcQ](id:22)",
-                        "description": null,
-                        "viz_type": "bar",
-                        "datasource_type": "table",
-                        "slice_name": "Number of commits per month breakdown per repo",
-                        "changed_on": {
-                            "__datetime__": "2019-06-14T13:57:02"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"annotation_layers\": [], \"bar_stacked\": true, \"bottom_margin\": \"auto\", \"color_scheme\": \"SUPERSET_DEFAULT\", \"comparison_type\": \"values\", \"contribution\": false, \"datasource\": \"22__table\", \"granularity_sqla\": \"commit_date\", \"groupby\": [\"repo\"], \"left_margin\": \"auto\", \"line_interpolation\": \"linear\", \"metrics\": [\"count\"], \"order_desc\": true, \"reduce_x_ticks\": true, \"resample_fillmethod\": null, \"resample_how\": null, \"resample_rule\": null, \"rich_tooltip\": true, \"rolling_type\": \"None\", \"row_limit\": 1000, \"show_bar_value\": false, \"show_brush\": \"no\", \"show_controls\": false, \"show_legend\": true, \"slice_id\": 13, \"time_grain_sqla\": \"P1M\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"url_params\": {}, \"viz_type\": \"bar\", \"x_axis_format\": \"smart_date\", \"x_axis_label\": \"\", \"x_axis_showminmax\": false, \"x_ticks_layout\": \"auto\", \"y_axis_bounds\": [null, null], \"y_axis_format\": \".3s\", \"y_axis_label\": \"\", \"y_axis_showminmax\": false, \"y_log_scale\": false, \"remote_id\": 13, \"datasource_name\": \"null.admin admin-Untitled Query-Wfqa9oVcQ\", \"schema\": \"null.admin admin-Untitled Query-Wfqa9oVcQ\", \"database_name\": \"gitbase\"}",
-                        "datasource_name": "null.admin admin-Untitled Query-Wfqa9oVcQ",
-                        "owners": [{
-                            "__User__": {
-                                "changed_by_fk": null,
-                                "active": true,
-                                "email": "admin@example.com",
-                                "last_login": {
-                                    "__datetime__": "2019-06-13T10:24:18"
-                                },
-                                "id": 1,
-                                "login_count": 1,
-                                "first_name": "admin",
-                                "fail_login_count": 0,
-                                "last_name": "admin",
-                                "created_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "username": "admin",
-                                "changed_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "password": "pbkdf2:sha256:50000$64PX8iD9$187fbff76d3f68e0f6b2df52054222556aac0ffab8b84616b0c92500239d2f2e",
-                                "created_by_fk": null
-                            }
-                        }]
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 23,
-                        "id": 14,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T14:46:23"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[None].[admin admin-Untitled Query-rpq4L7GFr](id:23)",
-                        "description": null,
-                        "viz_type": "dist_bar",
-                        "datasource_type": "table",
-                        "slice_name": "Total number of commits per repository",
-                        "changed_on": {
-                            "__datetime__": "2019-06-14T13:57:02"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"bar_stacked\": false, \"bottom_margin\": 100, \"color_scheme\": \"SUPERSET_DEFAULT\", \"columns\": [], \"contribution\": false, \"datasource\": \"23__table\", \"granularity_sqla\": null, \"groupby\": [\"repository_id\"], \"metrics\": [{\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 98, \"is_dttm\": false, \"python_date_format\": null, \"type\": \"LONGLONG\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": true, \"hasCustomLabel\": false, \"label\": \"MAX(n)\", \"optionName\": \"metric_ozqrfezkw4o_zf5mkt49ns\", \"sqlExpression\": null}], \"order_bars\": false, \"reduce_x_ticks\": false, \"row_limit\": 1000, \"show_bar_value\": false, \"show_controls\": false, \"show_legend\": false, \"slice_id\": 14, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"url_params\": {}, \"viz_type\": \"dist_bar\", \"x_axis_label\": \"\", \"x_ticks_layout\": \"staggered\", \"y_axis_format\": null, \"y_axis_label\": \"\", \"remote_id\": 14, \"datasource_name\": \"null.admin admin-Untitled Query-rpq4L7GFr\", \"schema\": \"null.admin admin-Untitled Query-rpq4L7GFr\", \"database_name\": \"gitbase\"}",
-                        "datasource_name": "null.admin admin-Untitled Query-rpq4L7GFr",
-                        "owners": [{
-                            "__User__": {
-                                "changed_by_fk": null,
-                                "active": true,
-                                "email": "admin@example.com",
-                                "last_login": {
-                                    "__datetime__": "2019-06-13T10:24:18"
-                                },
-                                "id": 1,
-                                "login_count": 1,
-                                "first_name": "admin",
-                                "fail_login_count": 0,
-                                "last_name": "admin",
-                                "created_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "username": "admin",
-                                "changed_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "password": "pbkdf2:sha256:50000$64PX8iD9$187fbff76d3f68e0f6b2df52054222556aac0ffab8b84616b0c92500239d2f2e",
-                                "created_by_fk": null
-                            }
-                        }]
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 24,
-                        "id": 15,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T14:58:11"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[None].[admin admin-Untitled Query-Kmw5frZ_b](id:24)",
-                        "description": null,
-                        "viz_type": "pie",
-                        "datasource_type": "table",
-                        "slice_name": "Number of files per languages",
-                        "changed_on": {
-                            "__datetime__": "2019-06-14T13:57:02"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"24__table\", \"donut\": false, \"granularity_sqla\": null, \"groupby\": [\"lang\"], \"labels_outside\": true, \"metric\": {\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 100, \"is_dttm\": false, \"optionName\": \"_col_n\", \"python_date_format\": null, \"type\": \"LONGLONG\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": true, \"hasCustomLabel\": false, \"label\": \"MAX(n)\", \"optionName\": \"metric_fgo2qfox5ct_76gkjbqjn0l\", \"sqlExpression\": null}, \"number_format\": \".3s\", \"pie_label_type\": \"key\", \"row_limit\": 1000, \"show_labels\": true, \"show_legend\": false, \"slice_id\": 15, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"url_params\": {}, \"viz_type\": \"pie\", \"remote_id\": 15, \"datasource_name\": \"null.admin admin-Untitled Query-Kmw5frZ_b\", \"schema\": \"null.admin admin-Untitled Query-Kmw5frZ_b\", \"database_name\": \"gitbase\"}",
-                        "datasource_name": "null.admin admin-Untitled Query-Kmw5frZ_b",
-                        "owners": [{
-                            "__User__": {
-                                "changed_by_fk": null,
-                                "active": true,
-                                "email": "admin@example.com",
-                                "last_login": {
-                                    "__datetime__": "2019-06-13T10:24:18"
-                                },
-                                "id": 1,
-                                "login_count": 1,
-                                "first_name": "admin",
-                                "fail_login_count": 0,
-                                "last_name": "admin",
-                                "created_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "username": "admin",
-                                "changed_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "password": "pbkdf2:sha256:50000$64PX8iD9$187fbff76d3f68e0f6b2df52054222556aac0ffab8b84616b0c92500239d2f2e",
-                                "created_by_fk": null
-                            }
-                        }]
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 26,
-                        "id": 17,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T15:11:33"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[None].[admin admin-Untitled Query-ykYJeoJJn](id:26)",
-                        "description": null,
-                        "viz_type": "pie",
-                        "datasource_type": "table",
-                        "slice_name": "Number of lines of code per language",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T15:46:34"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"26__table\", \"donut\": false, \"granularity_sqla\": null, \"groupby\": [\"lang\"], \"labels_outside\": true, \"metric\": {\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"sum_n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 104, \"is_dttm\": false, \"python_date_format\": null, \"type\": \"DOUBLE\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": true, \"hasCustomLabel\": false, \"label\": \"MAX(sum_n)\", \"optionName\": \"metric_9rbc46c8jz5_19sstwscubq\", \"sqlExpression\": null}, \"number_format\": \".3s\", \"pie_label_type\": \"key\", \"row_limit\": 1000, \"show_labels\": true, \"show_legend\": false, \"slice_id\": 17, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"pie\", \"remote_id\": 17, \"datasource_name\": \"null.admin admin-Untitled Query-ykYJeoJJn\", \"schema\": \"null.admin admin-Untitled Query-ykYJeoJJn\", \"database_name\": \"gitbase\"}",
-                        "datasource_name": "null.admin admin-Untitled Query-ykYJeoJJn",
-                        "owners": [{
-                            "__User__": {
-                                "changed_by_fk": null,
-                                "active": true,
-                                "email": "admin@example.com",
-                                "last_login": {
-                                    "__datetime__": "2019-06-13T10:24:18"
-                                },
-                                "id": 1,
-                                "login_count": 1,
-                                "first_name": "admin",
-                                "fail_login_count": 0,
-                                "last_name": "admin",
-                                "created_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "username": "admin",
-                                "changed_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "password": "pbkdf2:sha256:50000$64PX8iD9$187fbff76d3f68e0f6b2df52054222556aac0ffab8b84616b0c92500239d2f2e",
-                                "created_by_fk": null
-                            }
-                        }]
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 27,
-                        "id": 18,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T15:17:46"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[gitbase].[admin admin-Untitled Query-tEO1Ih2Uu](id:27)",
-                        "description": null,
-                        "viz_type": "pie",
-                        "datasource_type": "table",
-                        "slice_name": "Number of contributions per organization",
-                        "changed_on": {
-                            "__datetime__": "2019-06-14T14:38:42"
-                        },
-                        "changed_by_fk": null,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"27__table\", \"donut\": false, \"granularity_sqla\": null, \"groupby\": [\"domain\"], \"labels_outside\": true, \"metric\": {\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 106, \"is_dttm\": false, \"optionName\": \"_col_n\", \"python_date_format\": null, \"type\": \"LONGLONG\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": false, \"hasCustomLabel\": false, \"label\": \"MAX(n)\", \"optionName\": \"metric_g4rpo9wf9ew_ujjshbhz88\", \"sqlExpression\": null}, \"number_format\": \".3s\", \"pie_label_type\": \"key\", \"row_limit\": 1000, \"show_labels\": true, \"show_legend\": false, \"slice_id\": 18, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"url_params\": {}, \"viz_type\": \"pie\", \"remote_id\": 18, \"datasource_name\": \"null.admin admin-Untitled Query-tEO1Ih2Uu\", \"schema\": \"null.admin admin-Untitled Query-tEO1Ih2Uu\", \"database_name\": \"gitbase\"}",
-                        "datasource_name": "null.admin admin-Untitled Query-tEO1Ih2Uu",
-                        "owners": [{
-                            "__User__": {
-                                "changed_by_fk": null,
-                                "active": true,
-                                "email": "admin@example.com",
-                                "last_login": {
-                                    "__datetime__": "2019-06-13T10:24:18"
-                                },
-                                "id": 1,
-                                "login_count": 1,
-                                "first_name": "admin",
-                                "fail_login_count": 0,
-                                "last_name": "admin",
-                                "created_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "username": "admin",
-                                "changed_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "password": "pbkdf2:sha256:50000$64PX8iD9$187fbff76d3f68e0f6b2df52054222556aac0ffab8b84616b0c92500239d2f2e",
-                                "created_by_fk": null
-                            }
-                        }]
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 29,
-                        "id": 19,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T15:24:36"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[gitbase].[admin admin-Untitled Query-UnJl1GKQ8](id:29)",
-                        "description": null,
-                        "viz_type": "word_cloud",
-                        "datasource_type": "table",
-                        "slice_name": "Organization wordcloud",
-                        "changed_on": {
-                            "__datetime__": "2019-06-14T14:38:42"
-                        },
-                        "changed_by_fk": null,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"29__table\", \"granularity_sqla\": null, \"metric\": {\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 110, \"is_dttm\": false, \"optionName\": \"_col_n\", \"python_date_format\": null, \"type\": \"LONGLONG\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": false, \"hasCustomLabel\": false, \"label\": \"MAX(n)\", \"optionName\": \"metric_1yxqanppn5b_vz0jq5if73j\", \"sqlExpression\": null}, \"rotation\": \"square\", \"row_limit\": 250, \"series\": \"domain\", \"size_from\": 18, \"size_to\": 70, \"slice_id\": 19, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"url_params\": {}, \"viz_type\": \"word_cloud\", \"remote_id\": 19, \"datasource_name\": \"null.admin admin-Untitled Query-UnJl1GKQ8\", \"schema\": \"null.admin admin-Untitled Query-UnJl1GKQ8\", \"database_name\": \"gitbase\"}",
-                        "datasource_name": "null.admin admin-Untitled Query-UnJl1GKQ8",
-                        "owners": [{
-                            "__User__": {
-                                "changed_by_fk": null,
-                                "active": true,
-                                "email": "admin@example.com",
-                                "last_login": {
-                                    "__datetime__": "2019-06-13T10:24:18"
-                                },
-                                "id": 1,
-                                "login_count": 1,
-                                "first_name": "admin",
-                                "fail_login_count": 0,
-                                "last_name": "admin",
-                                "created_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "username": "admin",
-                                "changed_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "password": "pbkdf2:sha256:50000$64PX8iD9$187fbff76d3f68e0f6b2df52054222556aac0ffab8b84616b0c92500239d2f2e",
-                                "created_by_fk": null
-                            }
-                        }]
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 30,
-                        "id": 20,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T15:32:59"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[gitbase].[admin admin-Untitled Query-boJAIGUPS](id:30)",
-                        "description": null,
-                        "viz_type": "pie",
-                        "datasource_type": "table",
-                        "slice_name": "Number of contributions per email",
-                        "changed_on": {
-                            "__datetime__": "2019-06-14T13:57:02"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"30__table\", \"donut\": false, \"granularity_sqla\": null, \"groupby\": [\"committer_email\"], \"labels_outside\": true, \"metric\": {\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 112, \"is_dttm\": false, \"optionName\": \"_col_n\", \"python_date_format\": null, \"type\": \"LONGLONG\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": false, \"hasCustomLabel\": false, \"label\": \"MAX(n)\", \"optionName\": \"metric_ph1p73w244_tswjzepbscl\", \"sqlExpression\": null}, \"number_format\": \".3s\", \"pie_label_type\": \"key\", \"row_limit\": 1000, \"show_labels\": true, \"show_legend\": false, \"slice_id\": 20, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"url_params\": {}, \"viz_type\": \"pie\", \"remote_id\": 20, \"datasource_name\": \"null.admin admin-Untitled Query-boJAIGUPS\", \"schema\": \"null.admin admin-Untitled Query-boJAIGUPS\", \"database_name\": \"gitbase\"}",
-                        "datasource_name": "null.admin admin-Untitled Query-boJAIGUPS",
-                        "owners": [{
-                            "__User__": {
-                                "changed_by_fk": null,
-                                "active": true,
-                                "email": "admin@example.com",
-                                "last_login": {
-                                    "__datetime__": "2019-06-13T10:24:18"
-                                },
-                                "id": 1,
-                                "login_count": 1,
-                                "first_name": "admin",
-                                "fail_login_count": 0,
-                                "last_name": "admin",
-                                "created_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "username": "admin",
-                                "changed_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "password": "pbkdf2:sha256:50000$64PX8iD9$187fbff76d3f68e0f6b2df52054222556aac0ffab8b84616b0c92500239d2f2e",
-                                "created_by_fk": null
-                            }
-                        }]
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 32,
-                        "id": 21,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T15:37:33"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[gitbase].[admin admin-Untitled Query-JJ5b9O0Hc](id:32)",
-                        "description": null,
-                        "viz_type": "word_cloud",
-                        "datasource_type": "table",
-                        "slice_name": "Email wordcloud",
-                        "changed_on": {
-                            "__datetime__": "2019-06-14T13:57:02"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"32__table\", \"granularity_sqla\": null, \"metric\": {\"aggregate\": \"MAX\", \"column\": {\"column_name\": \"n\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 116, \"is_dttm\": false, \"optionName\": \"_col_n\", \"python_date_format\": null, \"type\": \"LONGLONG\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": false, \"hasCustomLabel\": false, \"label\": \"MAX(n)\", \"optionName\": \"metric_ajg1mqrbzth_tmqjky93xdc\", \"sqlExpression\": null}, \"rotation\": \"square\", \"row_limit\": 1000, \"series\": \"committer_email\", \"size_from\": 16, \"size_to\": 50, \"slice_id\": 21, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"url_params\": {}, \"viz_type\": \"word_cloud\", \"remote_id\": 21, \"datasource_name\": \"null.admin admin-Untitled Query-JJ5b9O0Hc\", \"schema\": \"null.admin admin-Untitled Query-JJ5b9O0Hc\", \"database_name\": \"gitbase\"}",
-                        "datasource_name": "null.admin admin-Untitled Query-JJ5b9O0Hc",
-                        "owners": [{
-                            "__User__": {
-                                "changed_by_fk": null,
-                                "active": true,
-                                "email": "admin@example.com",
-                                "last_login": {
-                                    "__datetime__": "2019-06-13T10:24:18"
-                                },
-                                "id": 1,
-                                "login_count": 1,
-                                "first_name": "admin",
-                                "fail_login_count": 0,
-                                "last_name": "admin",
-                                "created_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "username": "admin",
-                                "changed_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "password": "pbkdf2:sha256:50000$64PX8iD9$187fbff76d3f68e0f6b2df52054222556aac0ffab8b84616b0c92500239d2f2e",
-                                "created_by_fk": null
-                            }
-                        }]
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 33,
-                        "id": 22,
-                        "created_on": {
-                            "__datetime__": "2019-06-14T13:18:55"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[None].[admin admin-Untitled Query-CmGNVca6-](id:33)",
-                        "description": null,
-                        "viz_type": "table",
-                        "datasource_type": "table",
-                        "slice_name": "Repository by number of collaborators",
-                        "changed_on": {
-                            "__datetime__": "2019-06-14T13:57:02"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"align_pn\": false, \"all_columns\": [\"repository_id\", \"collaborators_count\"], \"color_pn\": true, \"datasource\": \"33__table\", \"granularity_sqla\": null, \"groupby\": [], \"include_search\": false, \"include_time\": false, \"metrics\": [], \"order_by_cols\": [], \"order_desc\": true, \"page_length\": 0, \"percent_metrics\": [], \"row_limit\": 1000, \"slice_id\": 22, \"table_filter\": false, \"table_timestamp_format\": \"%Y-%m-%d %H:%M:%S\", \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"table\", \"remote_id\": 22, \"datasource_name\": \"null.admin admin-Untitled Query-CmGNVca6-\", \"schema\": \"null.admin admin-Untitled Query-CmGNVca6-\", \"database_name\": \"gitbase\"}",
-                        "datasource_name": "null.admin admin-Untitled Query-CmGNVca6-",
-                        "owners": [{
-                            "__User__": {
-                                "changed_by_fk": null,
-                                "active": true,
-                                "email": "admin@example.com",
-                                "last_login": {
-                                    "__datetime__": "2019-06-13T10:24:18"
-                                },
-                                "id": 1,
-                                "login_count": 1,
-                                "first_name": "admin",
-                                "fail_login_count": 0,
-                                "last_name": "admin",
-                                "created_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "username": "admin",
-                                "changed_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "password": "pbkdf2:sha256:50000$64PX8iD9$187fbff76d3f68e0f6b2df52054222556aac0ffab8b84616b0c92500239d2f2e",
-                                "created_by_fk": null
-                            }
-                        }]
-                    }
-                },
-                {
-                    "__Slice__": {
-                        "datasource_id": 15,
-                        "id": 23,
-                        "created_on": {
-                            "__datetime__": "2019-06-14T13:42:16"
-                        },
-                        "created_by_fk": 1,
-                        "perm": "[gitbase].[admin admin-head_repo_languages-FJfWO1kQ4](id:15)",
-                        "description": null,
-                        "viz_type": "pie",
-                        "datasource_type": "table",
-                        "slice_name": "Languages",
-                        "changed_on": {
-                            "__datetime__": "2019-06-14T13:57:02"
-                        },
-                        "changed_by_fk": 1,
-                        "cache_timeout": null,
-                        "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"15__table\", \"donut\": true, \"granularity_sqla\": null, \"groupby\": [\"lang\"], \"labels_outside\": false, \"metric\": \"count\", \"number_format\": \".3s\", \"pie_label_type\": \"key\", \"row_limit\": 1000, \"show_labels\": true, \"show_legend\": false, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"pie\", \"remote_id\": 23, \"datasource_name\": \"gitbase.admin admin-head_repo_languages-FJfWO1kQ4\", \"schema\": \"gitbase.admin admin-head_repo_languages-FJfWO1kQ4\", \"database_name\": \"gitbase\"}",
-                        "datasource_name": "gitbase.admin admin-head_repo_languages-FJfWO1kQ4",
-                        "owners": [{
-                            "__User__": {
-                                "changed_by_fk": null,
-                                "active": true,
-                                "email": "admin@example.com",
-                                "last_login": {
-                                    "__datetime__": "2019-06-13T10:24:18"
-                                },
-                                "id": 1,
-                                "login_count": 1,
-                                "first_name": "admin",
-                                "fail_login_count": 0,
-                                "last_name": "admin",
-                                "created_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "username": "admin",
-                                "changed_on": {
-                                    "__datetime__": "2019-06-13T10:15:35"
-                                },
-                                "password": "pbkdf2:sha256:50000$64PX8iD9$187fbff76d3f68e0f6b2df52054222556aac0ffab8b84616b0c92500239d2f2e",
-                                "created_by_fk": null
-                            }
-                        }]
-                    }
-                }
-            ]
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
         }
-    }],
-    "datasources": [{
-            "__SqlaTable__": {
-                "schema": "gitbase",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T10:25:34"
-                },
-                "sql": "SELECT repository_id, COUNT(file_path) as files_count\r\nFROM refs\r\nNATURAL JOIN commit_files\r\nWHERE ref_name = 'HEAD'\r\nGROUP BY repository_id\r\nORDER BY files_count DESC",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-13T10:25:34"
-                },
-                "is_sqllab_view": false,
-                "params": "{\"remote_id\": 14, \"database_name\": \"gitbase\", \"import_time\": 1560421533}",
-                "id": 14,
-                "template_params": "{}",
-                "perm": "[gitbase].[admin admin-repo_files_count-XXcl9_d2Y](id:14)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-repo_files_count-XXcl9_d2Y",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 14,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "repository_id",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 70,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 14,
-                            "filterable": true,
-                            "type": "LONGLONG",
-                            "database_expression": null,
-                            "column_name": "files_count",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 71,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": false,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 15,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 14,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        }
-                    }
-                }]
-            }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "gitbase",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:35"
         },
-        {
-            "__SqlaTable__": {
-                "schema": "null",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T15:22:56"
-                },
-                "sql": "SELECT REPLACE(JSON_EXTRACT(SPLIT(committer_email, '@'), '$[1]'),'\"', '') as domain, COUNT(*) as n\nFROM commits\nWHERE committer_email LIKE '%%@%%' and committer_email NOT LIKE '%%@github.com'\nGROUP BY domain\nORDER BY n DESC",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-14T14:36:25"
-                },
-                "is_sqllab_view": true,
-                "params": "{\"remote_id\": 29, \"database_name\": \"gitbase\"}",
-                "id": 29,
-                "template_params": "{}",
-                "perm": "[gitbase].[admin admin-Untitled Query-UnJl1GKQ8](id:29)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-Untitled Query-UnJl1GKQ8",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T15:22:56"
-                            },
-                            "expression": "",
-                            "table_id": 29,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "domain",
-                            "changed_on": {
-                                "__datetime__": "2019-06-14T13:24:52"
-                            },
-                            "is_active": null,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 109,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T15:22:56"
-                            },
-                            "expression": "",
-                            "table_id": 29,
-                            "filterable": true,
-                            "type": "LONGLONG",
-                            "database_expression": null,
-                            "column_name": "n",
-                            "changed_on": {
-                                "__datetime__": "2019-06-14T13:24:52"
-                            },
-                            "is_active": null,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 110,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": null,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 30,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T15:22:56"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 29,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-14T13:24:52"
-                        }
-                    }
-                }]
-            }
+        "sql": "SELECT repository_id, COUNT(file_path) as files_count\r\nFROM refs\r\nNATURAL JOIN commit_files\r\nWHERE ref_name = 'HEAD'\r\nGROUP BY repository_id\r\nORDER BY files_count DESC",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:35"
         },
-        {
-            "__SqlaTable__": {
-                "schema": null,
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T10:43:17"
-                },
-                "sql": "SELECT commit_author_name\nFROM commits\nGROUP BY commit_author_name\nORDER BY commit_author_name",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-13T10:43:17"
-                },
-                "is_sqllab_view": true,
-                "params": "{\"remote_id\": 19, \"database_name\": \"gitbase\"}",
-                "id": 19,
-                "template_params": "{}",
-                "perm": "[None].[admin admin-Untitled Query-mW48VqXdL](id:19)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-Untitled Query-mW48VqXdL",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                    "__TableColumn__": {
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:43:17"
-                        },
-                        "expression": "",
-                        "table_id": 19,
-                        "filterable": true,
-                        "type": "BLOB",
-                        "database_expression": null,
-                        "column_name": "commit_author_name",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:43:17"
-                        },
-                        "is_active": true,
-                        "python_date_format": null,
-                        "is_dttm": false,
-                        "description": null,
-                        "groupby": true,
-                        "created_by_fk": 1,
-                        "verbose_name": null,
-                        "id": 88,
-                        "changed_by_fk": 1
-                    }
-                }],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": false,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 20,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:43:17"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 19,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:43:17"
-                        }
-                    }
-                }]
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 12, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 12,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-repo_files_count-XXcl9_d2Y](id:12)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-repo_files_count-XXcl9_d2Y",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 12,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "column_name": "repository_id",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 53,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              }
             }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "gitbase",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T10:25:34"
-                },
-                "sql": "SELECT\r\n    repo,\r\n    CASE\r\n        WHEN day_index = 2 THEN '1 - Monday'\r\n        WHEN day_index = 3 THEN '2 - Tuesday'\r\n        WHEN day_index = 4 THEN '3 - Wednesday'\r\n        WHEN day_index = 5 THEN '4 - Thursday'\r\n        WHEN day_index = 6 THEN '5 - Friday'\r\n        WHEN day_index = 7 THEN '6 - Saturday'\r\n        ELSE '7 - Sunday'\r\n    END AS day,\r\n    CASE\r\n        WHEN n_parents > 1 THEN 'Merge commit'\r\n        ELSE 'Non-merge commit'\r\n    END AS commit_type\r\nFROM (\r\n    SELECT\r\n        repository_id AS repo,\r\n        DAYOFWEEK(committer_when) AS day_index,\r\n        ARRAY_LENGTH(commit_parents) AS n_parents\r\n    FROM commits\r\n) t",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-13T10:25:34"
-                },
-                "is_sqllab_view": false,
-                "params": "{\"remote_id\": 17, \"database_name\": \"gitbase\", \"import_time\": 1560421533}",
-                "id": 17,
-                "template_params": "{}",
-                "perm": "[gitbase].[admin admin-commits_per_day-lGJ1u0Kbm](id:17)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-commits_per_day-lGJ1u0Kbm",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 17,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "repo",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 77,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 17,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "day",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 78,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 17,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "commit_type",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 79,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": false,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 18,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 17,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        }
-                    }
-                }]
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 12,
+              "filterable": true,
+              "type": "LONGLONG",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "column_name": "files_count",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 54,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              }
             }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "null",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T14:55:41"
-                },
-                "sql": "SELECT lang, COUNT(*) as n\nFROM (\nSELECT LANGUAGE(cf.file_path, f.blob_content) as lang\nFROM files AS f\nNATURAL JOIN commit_files cf\nNATURAL JOIN refs\nWHERE ref_name = 'HEAD'\nAND file_path NOT LIKE 'vendor/%%'\n) AS t\nWHERE lang is not null\nGROUP BY lang\nORDER BY 2 DESC",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-13T14:55:41"
-                },
-                "is_sqllab_view": true,
-                "params": "{\"remote_id\": 24, \"database_name\": \"gitbase\"}",
-                "id": 24,
-                "template_params": "{}",
-                "perm": "[None].[admin admin-Untitled Query-Kmw5frZ_b](id:24)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-Untitled Query-Kmw5frZ_b",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T14:55:41"
-                            },
-                            "expression": "",
-                            "table_id": 24,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "lang",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T14:55:41"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 99,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T14:55:41"
-                            },
-                            "expression": "",
-                            "table_id": 24,
-                            "filterable": true,
-                            "type": "LONGLONG",
-                            "database_expression": null,
-                            "column_name": "n",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T14:55:41"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 100,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": false,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 25,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T14:55:41"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 24,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T14:55:41"
-                        }
-                    }
-                }]
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "id": 12,
+              "created_by_fk": null,
+              "table_id": 12,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "changed_by_fk": null
             }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "null",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T14:43:03"
-                },
-                "sql": "SELECT repository_id, COUNT(*) as n\nFROM ref_commits\nWHERE ref_name = 'HEAD'\nGROUP BY repository_id\nORDER BY n DESC\nLIMIT 20",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-13T14:43:03"
-                },
-                "is_sqllab_view": true,
-                "params": "{\"remote_id\": 23, \"database_name\": \"gitbase\"}",
-                "id": 23,
-                "template_params": "{}",
-                "perm": "[None].[admin admin-Untitled Query-rpq4L7GFr](id:23)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-Untitled Query-rpq4L7GFr",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T14:43:03"
-                            },
-                            "expression": "",
-                            "table_id": 23,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "repository_id",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T14:43:03"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 97,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T14:43:03"
-                            },
-                            "expression": "",
-                            "table_id": 23,
-                            "filterable": true,
-                            "type": "LONGLONG",
-                            "database_expression": null,
-                            "column_name": "n",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T14:43:03"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 98,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": false,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 24,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T14:43:03"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 23,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T14:43:03"
-                        }
-                    }
-                }]
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "null",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T14:11:19"
-                },
-                "sql": "SELECT commit_author_when,\nCOUNT(*) as n\nFROM ref_commits\nNATURAL JOIN commits\nWHERE ref_name = 'HEAD'\nGROUP BY commit_author_when\nORDER BY commit_author_when",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-13T14:11:19"
-                },
-                "is_sqllab_view": true,
-                "params": "{\"remote_id\": 21, \"database_name\": \"gitbase\"}",
-                "id": 21,
-                "template_params": "{}",
-                "perm": "[None].[admin admin-Untitled Query-0scA3HaD5](id:21)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-Untitled Query-0scA3HaD5",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T14:11:19"
-                            },
-                            "expression": "",
-                            "table_id": 21,
-                            "filterable": true,
-                            "type": "TIMESTAMP",
-                            "database_expression": null,
-                            "column_name": "commit_author_when",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T14:11:19"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": true,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 92,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T14:11:19"
-                            },
-                            "expression": "",
-                            "table_id": 21,
-                            "filterable": true,
-                            "type": "LONGLONG",
-                            "database_expression": null,
-                            "column_name": "n",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T14:11:19"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 93,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": false,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 22,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T14:11:19"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 21,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T14:11:19"
-                        }
-                    }
-                }]
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "null",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T15:09:33"
-                },
-                "sql": "SELECT lang, SUM(n) as sum_n\nFROM (\nSELECT lang, SUM(lines) as n\nFROM (\nSELECT f.repository_id, LANGUAGE(cf.file_path, f.blob_content) as lang,\nARRAY_LENGTH(SPLIT(f.blob_content, '\\n')) as lines\nFROM files AS f\nNATURAL JOIN commit_files cf\nNATURAL JOIN refs\nWHERE ref_name = 'HEAD'\nAND file_path NOT LIKE 'vendor/%%'\n) AS t\nWHERE lang IS NOT NULL\nGROUP BY repository_id, lang\n) AS t\nGROUP by lang\nORDER BY n DESC",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-13T15:09:33"
-                },
-                "is_sqllab_view": true,
-                "params": "{\"remote_id\": 26, \"database_name\": \"gitbase\"}",
-                "id": 26,
-                "template_params": "{}",
-                "perm": "[None].[admin admin-Untitled Query-ykYJeoJJn](id:26)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-Untitled Query-ykYJeoJJn",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T15:09:33"
-                            },
-                            "expression": "",
-                            "table_id": 26,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "lang",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T15:09:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 103,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T15:09:33"
-                            },
-                            "expression": "",
-                            "table_id": 26,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "sum_n",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T15:09:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 104,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": false,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 27,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T15:09:33"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 26,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T15:09:33"
-                        }
-                    }
-                }]
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "gitbase",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T10:25:34"
-                },
-                "sql": "SELECT\r\n    repository_id,\r\n    commit_author_when,\r\n    CASE ARRAY_LENGTH(commit_parents) WHEN 0 THEN 'Commit' WHEN 1 THEN 'Commit' ELSE 'Merge' END AS commit_type\r\nFROM commits",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-13T10:25:34"
-                },
-                "is_sqllab_view": false,
-                "params": "{\"remote_id\": 16, \"database_name\": \"gitbase\", \"import_time\": 1560421533}",
-                "id": 16,
-                "template_params": "{}",
-                "perm": "[gitbase].[admin admin-commit_merges-8X2HBrQre](id:16)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-commit_merges-8X2HBrQre",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 16,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "repository_id",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 74,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 16,
-                            "filterable": true,
-                            "type": "TIMESTAMP",
-                            "database_expression": null,
-                            "column_name": "commit_author_when",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": true,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 75,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 16,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "commit_type",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 76,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": false,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 17,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 16,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        }
-                    }
-                }]
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "gitbase",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T10:25:34"
-                },
-                "sql": "SELECT repository_id, lang\r\nFROM (\r\n    SELECT\r\n        repository_id,\r\n        LANGUAGE(file_path) as lang\r\n    FROM refs\r\n    NATURAL JOIN commit_files\r\n    WHERE ref_name = 'HEAD'\r\n) AS q\r\nWHERE lang NOT IN ('', 'Ignore List')",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-13T10:25:34"
-                },
-                "is_sqllab_view": false,
-                "params": "{\"remote_id\": 15, \"database_name\": \"gitbase\", \"import_time\": 1560421533}",
-                "id": 15,
-                "template_params": "{}",
-                "perm": "[gitbase].[admin admin-head_repo_languages-FJfWO1kQ4](id:15)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-head_repo_languages-FJfWO1kQ4",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 15,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "repository_id",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 72,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 15,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "lang",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 73,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": false,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 16,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 15,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        }
-                    }
-                }]
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "null",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T15:32:28"
-                },
-                "sql": "SELECT committer_email, COUNT(*) as n\nFROM commits\nWHERE committer_email <> 'noreply@github.com'\nGROUP BY committer_email\nORDER BY n DESC",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-14T12:50:46"
-                },
-                "is_sqllab_view": true,
-                "params": "{\"remote_id\": 30, \"database_name\": \"gitbase\"}",
-                "id": 30,
-                "template_params": "{}",
-                "perm": "[gitbase].[admin admin-Untitled Query-boJAIGUPS](id:30)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-Untitled Query-boJAIGUPS",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T15:32:28"
-                            },
-                            "expression": "",
-                            "table_id": 30,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "committer_email",
-                            "changed_on": {
-                                "__datetime__": "2019-06-14T12:50:46"
-                            },
-                            "is_active": null,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 111,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T15:32:28"
-                            },
-                            "expression": "",
-                            "table_id": 30,
-                            "filterable": true,
-                            "type": "LONGLONG",
-                            "database_expression": null,
-                            "column_name": "n",
-                            "changed_on": {
-                                "__datetime__": "2019-06-14T12:50:46"
-                            },
-                            "is_active": null,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 112,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": null,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 31,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T15:32:28"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 30,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-14T12:50:46"
-                        }
-                    }
-                }]
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "gitbase",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T10:25:33"
-                },
-                "sql": "SELECT \r\n    repository_id, \r\n    CASE WHEN MAX(changelog) = 0 THEN 'missing' ELSE '' END as changelog, \r\n    CASE WHEN MAX(readme) = 0 THEN 'missing' ELSE '' END as readme, \r\n    CASE WHEN MAX(notice) = 0 THEN 'missing' ELSE '' END as notice, \r\n    CASE WHEN MAX(license) = 0 THEN 'missing' ELSE '' END as license,\r\n    CASE WHEN MAX(contributing) = 0 THEN 'missing' ELSE '' END as contributing,\r\n    CASE WHEN MAX(travis) = 0 THEN 'missing' ELSE '' END as travis, \r\n    CASE WHEN MAX(ci) = 0 THEN 'missing' ELSE '' END as ci, \r\n    CASE WHEN MAX(dockerfile) = 0 THEN 'missing' ELSE '' END as dockerfile\r\nFROM (\r\n    SELECT \r\n        refs.repository_id, \r\n        CASE WHEN file_path REGEXP '(?i)^CHANGELOG(|\\.MD)' THEN 1 ELSE 0 END AS changelog,\r\n        CASE WHEN file_path REGEXP '(?i)^README(|\\.MD)' THEN 1 ELSE 0 END AS readme,\r\n        CASE WHEN file_path REGEXP '(?i)^NOTICE(|\\.MD)' THEN 1 ELSE 0 END AS notice,\r\n        CASE WHEN file_path REGEXP '(?i)^LICENSE(|\\.MD)' THEN 1 ELSE 0 END AS license,\r\n        CASE WHEN file_path REGEXP '(?i)^CONTRIBUTING(|\\.MD)' THEN 1 ELSE 0 END AS contributing,\r\n        CASE WHEN file_path REGEXP '(?i)^\\.TRAVIS\\.YML' THEN 1 ELSE 0 END AS travis,\r\n        CASE WHEN file_path REGEXP '(?i)^CI' THEN 1 ELSE 0 END AS ci,\r\n        CASE WHEN file_path REGEXP '(?i)^DOCKERFILE$' THEN 1 ELSE 0 END AS dockerfile\r\n    FROM refs\r\n    JOIN commit_files \r\n    ON refs.commit_hash = commit_files.commit_hash \r\n    WHERE ref_name = \"refs/heads/master\" \r\n) q\r\nGROUP BY repository_id",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-13T10:25:34"
-                },
-                "is_sqllab_view": false,
-                "params": "{\"remote_id\": 13, \"database_name\": \"gitbase\", \"import_time\": 1560421533}",
-                "id": 13,
-                "template_params": "{}",
-                "perm": "[gitbase].[admin admin-missing_files-Y0yDW8RN6](id:13)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-missing_files-Y0yDW8RN6",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 13,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "repository_id",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 61,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 13,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "changelog",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 62,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 13,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "readme",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 63,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 13,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "notice",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 64,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 13,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "license",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 65,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 13,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "contributing",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 66,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 13,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "travis",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 67,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 13,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "ci",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 68,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 13,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "dockerfile",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 69,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": false,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 14,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:25:33"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 13,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:25:33"
-                        }
-                    }
-                }]
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "null",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T13:37:01"
-                },
-                "sql": "SELECT repository_id, commit_author_when as date,\nCOUNT(*) as n\nFROM refs\nNATURAL JOIN commits\nWHERE ref_name LIKE 'refs/tags/v%.%.%'\nGROUP BY repository_id\nORDER BY repository_id",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-13T13:37:01"
-                },
-                "is_sqllab_view": true,
-                "params": "{\"remote_id\": 20, \"database_name\": \"gitbase\"}",
-                "id": 20,
-                "template_params": "{}",
-                "perm": "[None].[admin admin-Untitled Query-LUNdDHhhu](id:20)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-Untitled Query-LUNdDHhhu",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T13:37:01"
-                            },
-                            "expression": "",
-                            "table_id": 20,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "repository_id",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T13:37:01"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 89,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T13:37:01"
-                            },
-                            "expression": "",
-                            "table_id": 20,
-                            "filterable": true,
-                            "type": "TIMESTAMP",
-                            "database_expression": null,
-                            "column_name": "date",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T13:37:01"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": true,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 90,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T13:37:01"
-                            },
-                            "expression": "",
-                            "table_id": 20,
-                            "filterable": true,
-                            "type": "LONGLONG",
-                            "database_expression": null,
-                            "column_name": "n",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T13:37:01"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 91,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": false,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 21,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T13:37:01"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 20,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T13:37:01"
-                        }
-                    }
-                }]
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "gitbase",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T10:25:34"
-                },
-                "sql": "SELECT \r\n    SUM(1-changelog) as changelog, \r\n    SUM(1-readme) as readme, \r\n    SUM(1-notice) as notice, \r\n    SUM(1-license) as license,\r\n    SUM(1-contributing) as contributing,\r\n    SUM(1-travis) as travis,\r\n    SUM(1-ci) as ci,\r\n    SUM(1-dockerfile) as dockerfile\r\nFROM (\r\n\tSELECT \r\n\t    repository_id, \r\n\t    SUM(changelog) != 0 as changelog, \r\n        SUM(readme) != 0 as readme, \r\n        SUM(notice) != 0 as notice, \r\n        SUM(license) != 0 as license,\r\n        SUM(contributing) != 0 as contributing,\r\n        SUM(travis) != 0 as travis,\r\n        SUM(ci) != 0 as ci,\r\n    \tSUM(dockerfile) != 0 as dockerfile\r\n\tFROM (\r\n\t    SELECT \r\n\t        refs.repository_id, \r\n\t        CASE WHEN file_path REGEXP '(?i)^CHANGELOG(|\\.MD)' THEN 1 ELSE 0 END AS changelog,\r\n            CASE WHEN file_path REGEXP '(?i)^README(|\\.MD)' THEN 1 ELSE 0 END AS readme,\r\n            CASE WHEN file_path REGEXP '(?i)^NOTICE(|\\.MD)' THEN 1 ELSE 0 END AS notice,\r\n            CASE WHEN file_path REGEXP '(?i)^LICENSE(|\\.MD)' THEN 1 ELSE 0 END AS license,\r\n            CASE WHEN file_path REGEXP '(?i)^CONTRIBUTING(|\\.MD)' THEN 1 ELSE 0 END AS contributing,\r\n            CASE WHEN file_path REGEXP '(?i)^\\.TRAVIS\\.YML' THEN 1 ELSE 0 END AS travis,\r\n            CASE WHEN file_path REGEXP '(?i)^CI' THEN 1 ELSE 0 END AS ci,\r\n            CASE WHEN file_path REGEXP '(?i)^DOCKERFILE$' THEN 1 ELSE 0 END AS dockerfile\r\n\t    FROM refs\r\n\t    JOIN commit_files \r\n\t    ON refs.commit_hash = commit_files.commit_hash \r\n\t    WHERE ref_name = \"refs/heads/master\" \r\n\t) q\r\n\tGROUP BY repository_id\r\n) q2\r",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-13T10:25:34"
-                },
-                "is_sqllab_view": false,
-                "params": "{\"remote_id\": 18, \"database_name\": \"gitbase\", \"import_time\": 1560421533}",
-                "id": 18,
-                "template_params": "{}",
-                "perm": "[gitbase].[admin admin-missing_files_summary-YqNVbLHqJ](id:18)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-missing_files_summary-YqNVbLHqJ",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 18,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "changelog",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 80,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 18,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "readme",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 81,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 18,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "notice",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 82,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 18,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "license",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 83,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 18,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "contributing",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 84,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 18,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "travis",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 85,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 18,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "ci",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 86,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "expression": "",
-                            "table_id": 18,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "dockerfile",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:34"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 87,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": false,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 19,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 18,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:25:34"
-                        }
-                    }
-                }]
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "null",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-14T13:18:14"
-                },
-                "sql": "SELECT repository_id, COUNT(commit_author_name) as collaborators_count FROM (\nSELECT DISTINCT commit_author_name, repository_id\nFROM commits\n) q1\nGROUP BY repository_id\nORDER BY collaborators_count DESC",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-14T13:18:14"
-                },
-                "is_sqllab_view": true,
-                "params": "{\"remote_id\": 33, \"database_name\": \"gitbase\"}",
-                "id": 33,
-                "template_params": "{}",
-                "perm": "[None].[admin admin-Untitled Query-CmGNVca6-](id:33)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-Untitled Query-CmGNVca6-",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-14T13:18:14"
-                            },
-                            "expression": "",
-                            "table_id": 33,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "repository_id",
-                            "changed_on": {
-                                "__datetime__": "2019-06-14T13:18:14"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 117,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-14T13:18:14"
-                            },
-                            "expression": "",
-                            "table_id": 33,
-                            "filterable": true,
-                            "type": "LONGLONG",
-                            "database_expression": null,
-                            "column_name": "collaborators_count",
-                            "changed_on": {
-                                "__datetime__": "2019-06-14T13:18:14"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 118,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": false,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 34,
-                        "created_on": {
-                            "__datetime__": "2019-06-14T13:18:14"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 33,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-14T13:18:14"
-                        }
-                    }
-                }]
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "null",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T14:25:37"
-                },
-                "sql": "SELECT repository_id as repo,\ncommit_author_when commit_date,\nCOUNT(*) as n\nFROM commits\nWHERE commit_author_when <= now()\nGROUP BY repo, commit_date\nORDER BY repo, commit_date",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-13T14:25:37"
-                },
-                "is_sqllab_view": true,
-                "params": "{\"remote_id\": 22, \"database_name\": \"gitbase\"}",
-                "id": 22,
-                "template_params": "{}",
-                "perm": "[None].[admin admin-Untitled Query-Wfqa9oVcQ](id:22)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-Untitled Query-Wfqa9oVcQ",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T14:25:37"
-                            },
-                            "expression": "",
-                            "table_id": 22,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "repo",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T14:25:37"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 94,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T14:25:37"
-                            },
-                            "expression": "",
-                            "table_id": 22,
-                            "filterable": true,
-                            "type": "TIMESTAMP",
-                            "database_expression": null,
-                            "column_name": "commit_date",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T14:25:37"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": true,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 95,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T14:25:37"
-                            },
-                            "expression": "",
-                            "table_id": 22,
-                            "filterable": true,
-                            "type": "LONGLONG",
-                            "database_expression": null,
-                            "column_name": "n",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T14:25:37"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 96,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": false,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 23,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T14:25:37"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 22,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T14:25:37"
-                        }
-                    }
-                }]
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "gitbase",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T10:25:33"
-                },
-                "sql": "SELECT \r\n    SUM(changelog != 0) / COUNT(changelog)  as changelog, \r\n    SUM(readme != 0)  / COUNT(changelog) as readme, \r\n    SUM(notice != 0)  / COUNT(changelog) as notice, \r\n    SUM(license != 0) / COUNT(changelog) as license,\r\n    SUM(contributing != 0) / COUNT(changelog) as contributing,\r\n    SUM(travis != 0) / COUNT(changelog) as travis, \r\n    SUM(ci != 0) / COUNT(changelog) as ci, \r\n    SUM(dockerfile != 0) / COUNT(changelog) as dockerfile \r\nFROM (\r\n    SELECT \r\n        SUM(changelog) as changelog, \r\n        SUM(readme) as readme, \r\n        SUM(notice) as notice, \r\n        SUM(license) as license,\r\n        SUM(contributing) as contributing,\r\n        SUM(travis) as travis,\r\n        SUM(ci) as ci,\r\n        SUM(dockerfile) as dockerfile\r\n    FROM (\r\n        SELECT \r\n            refs.repository_id, \r\n            CASE WHEN file_path REGEXP '(?i)^CHANGELOG(|\\.MD)' THEN 1 ELSE 0 END AS changelog,\r\n            CASE WHEN file_path REGEXP '(?i)^README(|\\.MD)' THEN 1 ELSE 0 END AS readme,\r\n            CASE WHEN file_path REGEXP '(?i)^NOTICE(|\\.MD)' THEN 1 ELSE 0 END AS notice,\r\n            CASE WHEN file_path REGEXP '(?i)^LICENSE(|\\.MD)' THEN 1 ELSE 0 END AS license,\r\n            CASE WHEN file_path REGEXP '(?i)^CONTRIBUTING(|\\.MD)' THEN 1 ELSE 0 END AS contributing,\r\n            CASE WHEN file_path REGEXP '(?i)^\\.TRAVIS\\.YML' THEN 1 ELSE 0 END AS travis,\r\n            CASE WHEN file_path REGEXP '(?i)^CI' THEN 1 ELSE 0 END AS ci,\r\n            CASE WHEN file_path REGEXP '(?i)^DOCKERFILE$' THEN 1 ELSE 0 END AS dockerfile\r\n        FROM refs\r\n        JOIN commit_files \r\n        ON refs.commit_hash = commit_files.commit_hash \r\n        WHERE ref_name = \"refs/heads/master\" \r\n    ) q\r\n    GROUP BY repository_id\r\n) q2",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-13T10:25:33"
-                },
-                "is_sqllab_view": false,
-                "params": "{\"remote_id\": 12, \"database_name\": \"gitbase\", \"import_time\": 1560421533}",
-                "id": 12,
-                "template_params": "{}",
-                "perm": "[gitbase].[admin admin-compliance_score-ReDkKHp6n](id:12)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-compliance_score-ReDkKHp6n",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 12,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "changelog",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 53,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 12,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "readme",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 54,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 12,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "notice",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 55,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 12,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "license",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 56,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 12,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "contributing",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 57,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 12,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "travis",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 58,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 12,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "ci",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 59,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "expression": "",
-                            "table_id": 12,
-                            "filterable": true,
-                            "type": "DOUBLE",
-                            "database_expression": null,
-                            "column_name": "dockerfile",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "is_active": true,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 60,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                        "__SqlMetric__": {
-                            "changed_by_fk": 1,
-                            "expression": "count(*)",
-                            "warning_text": null,
-                            "is_restricted": false,
-                            "metric_type": null,
-                            "verbose_name": null,
-                            "id": 12,
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "created_by_fk": 1,
-                            "table_id": 12,
-                            "d3format": null,
-                            "description": null,
-                            "metric_name": "count",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            }
-                        }
-                    },
-                    {
-                        "__SqlMetric__": {
-                            "changed_by_fk": 1,
-                            "expression": "(changelog + 3 * readme + 3 * notice + 3 * license + contributing + travis + ci + Dockerfile) / 14.0",
-                            "warning_text": null,
-                            "is_restricted": false,
-                            "metric_type": null,
-                            "verbose_name": "compliance",
-                            "id": 13,
-                            "created_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            },
-                            "created_by_fk": 1,
-                            "table_id": 12,
-                            "d3format": null,
-                            "description": null,
-                            "metric_name": "compliance",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T10:25:33"
-                            }
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "null",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T15:16:04"
-                },
-                "sql": "SELECT REPLACE(JSON_EXTRACT(SPLIT(committer_email, '@'), '$[1]'),'\"', '') as domain, COUNT(*) as n\nFROM commits\nWHERE committer_email LIKE '%%@%%' and committer_email NOT LIKE '%%@github.com'\nGROUP BY domain\nORDER BY n DESC",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-14T14:35:47"
-                },
-                "is_sqllab_view": true,
-                "params": "{\"remote_id\": 27, \"database_name\": \"gitbase\"}",
-                "id": 27,
-                "template_params": "{}",
-                "perm": "[gitbase].[admin admin-Untitled Query-tEO1Ih2Uu](id:27)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-Untitled Query-tEO1Ih2Uu",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T15:16:04"
-                            },
-                            "expression": "",
-                            "table_id": 27,
-                            "filterable": true,
-                            "type": "STRING",
-                            "database_expression": null,
-                            "column_name": "domain",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T15:26:10"
-                            },
-                            "is_active": null,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 105,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T15:16:04"
-                            },
-                            "expression": "",
-                            "table_id": 27,
-                            "filterable": true,
-                            "type": "LONGLONG",
-                            "database_expression": null,
-                            "column_name": "n",
-                            "changed_on": {
-                                "__datetime__": "2019-06-13T15:26:10"
-                            },
-                            "is_active": null,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 106,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": null,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 28,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T15:16:04"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 27,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T15:26:10"
-                        }
-                    }
-                }]
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": null,
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T10:16:00"
-                },
-                "sql": "select * from repositories",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-13T10:25:34"
-                },
-                "is_sqllab_view": false,
-                "params": "{\"remote_id\": 10, \"database_name\": \"gitbase\", \"import_time\": 1560421533}",
-                "id": 10,
-                "template_params": null,
-                "perm": "[gitbase].[gitbase.repositories](id:10)",
-                "description": null,
-                "created_by_fk": null,
-                "table_name": "gitbase.repositories",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                    "__TableColumn__": {
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:16:00"
-                        },
-                        "expression": "",
-                        "table_id": 10,
-                        "filterable": false,
-                        "type": "TEXT",
-                        "database_expression": null,
-                        "column_name": "repository_id",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:16:06"
-                        },
-                        "is_active": true,
-                        "python_date_format": null,
-                        "is_dttm": false,
-                        "description": null,
-                        "groupby": false,
-                        "created_by_fk": null,
-                        "verbose_name": null,
-                        "id": 47,
-                        "changed_by_fk": null
-                    }
-                }],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": null,
-                        "expression": "COUNT(*)",
-                        "warning_text": null,
-                        "is_restricted": false,
-                        "metric_type": "count",
-                        "verbose_name": "COUNT(*)",
-                        "id": 10,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:16:00"
-                        },
-                        "created_by_fk": null,
-                        "table_id": 10,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:16:00"
-                        }
-                    }
-                }]
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "schema": "null",
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-13T15:35:41"
-                },
-                "sql": "SELECT committer_email, COUNT(*) as n\nFROM commits\nWHERE committer_email <> 'noreply@github.com'\nGROUP BY committer_email\nORDER BY n DESC",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-14T12:51:53"
-                },
-                "is_sqllab_view": true,
-                "params": "{\"remote_id\": 32, \"database_name\": \"gitbase\"}",
-                "id": 32,
-                "template_params": "{}",
-                "perm": "[gitbase].[admin admin-Untitled Query-JJ5b9O0Hc](id:32)",
-                "description": null,
-                "created_by_fk": 1,
-                "table_name": "admin admin-Untitled Query-JJ5b9O0Hc",
-                "default_endpoint": null,
-                "changed_by_fk": 1,
-                "main_dttm_col": null,
-                "is_featured": false,
-                "database_id": 2,
-                "filter_select_enabled": false,
-                "fetch_values_predicate": null,
-                "database": {
-                    "__Database__": {
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false,
-                        "perm": "[gitbase].(id:2)",
-                        "changed_on": {
-                            "__datetime__": "2019-06-13T10:15:58"
-                        },
-                        "expose_in_sqllab": true,
-                        "id": 2,
-                        "impersonate_user": false,
-                        "allow_run_async": true
-                    }
-                },
-                "columns": [{
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T15:35:41"
-                            },
-                            "expression": "",
-                            "table_id": 32,
-                            "filterable": true,
-                            "type": "BLOB",
-                            "database_expression": null,
-                            "column_name": "committer_email",
-                            "changed_on": {
-                                "__datetime__": "2019-06-14T12:51:53"
-                            },
-                            "is_active": null,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 115,
-                            "changed_by_fk": 1
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "created_on": {
-                                "__datetime__": "2019-06-13T15:35:41"
-                            },
-                            "expression": "",
-                            "table_id": 32,
-                            "filterable": true,
-                            "type": "LONGLONG",
-                            "database_expression": null,
-                            "column_name": "n",
-                            "changed_on": {
-                                "__datetime__": "2019-06-14T12:51:53"
-                            },
-                            "is_active": null,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": true,
-                            "created_by_fk": 1,
-                            "verbose_name": null,
-                            "id": 116,
-                            "changed_by_fk": 1
-                        }
-                    }
-                ],
-                "metrics": [{
-                    "__SqlMetric__": {
-                        "changed_by_fk": 1,
-                        "expression": "count(*)",
-                        "warning_text": null,
-                        "is_restricted": null,
-                        "metric_type": null,
-                        "verbose_name": null,
-                        "id": 33,
-                        "created_on": {
-                            "__datetime__": "2019-06-13T15:35:41"
-                        },
-                        "created_by_fk": 1,
-                        "table_id": 32,
-                        "d3format": null,
-                        "description": null,
-                        "metric_name": "count",
-                        "changed_on": {
-                            "__datetime__": "2019-06-14T12:51:53"
-                        }
-                    }
-                }]
-            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
         }
-    ]
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "gitbase",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:37"
+        },
+        "sql": "SELECT \r\n    SUM(1-changelog) as changelog, \r\n    SUM(1-readme) as readme, \r\n    SUM(1-notice) as notice, \r\n    SUM(1-license) as license,\r\n    SUM(1-contributing) as contributing,\r\n    SUM(1-travis) as travis,\r\n    SUM(1-ci) as ci,\r\n    SUM(1-dockerfile) as dockerfile\r\nFROM (\r\n\tSELECT \r\n\t    repository_id, \r\n\t    SUM(changelog) != 0 as changelog, \r\n        SUM(readme) != 0 as readme, \r\n        SUM(notice) != 0 as notice, \r\n        SUM(license) != 0 as license,\r\n        SUM(contributing) != 0 as contributing,\r\n        SUM(travis) != 0 as travis,\r\n        SUM(ci) != 0 as ci,\r\n    \tSUM(dockerfile) != 0 as dockerfile\r\n\tFROM (\r\n\t    SELECT \r\n\t        refs.repository_id, \r\n\t        CASE WHEN file_path REGEXP '(?i)^CHANGELOG(|\\.MD)' THEN 1 ELSE 0 END AS changelog,\r\n            CASE WHEN file_path REGEXP '(?i)^README(|\\.MD)' THEN 1 ELSE 0 END AS readme,\r\n            CASE WHEN file_path REGEXP '(?i)^NOTICE(|\\.MD)' THEN 1 ELSE 0 END AS notice,\r\n            CASE WHEN file_path REGEXP '(?i)^LICENSE(|\\.MD)' THEN 1 ELSE 0 END AS license,\r\n            CASE WHEN file_path REGEXP '(?i)^CONTRIBUTING(|\\.MD)' THEN 1 ELSE 0 END AS contributing,\r\n            CASE WHEN file_path REGEXP '(?i)^\\.TRAVIS\\.YML' THEN 1 ELSE 0 END AS travis,\r\n            CASE WHEN file_path REGEXP '(?i)^CI' THEN 1 ELSE 0 END AS ci,\r\n            CASE WHEN file_path REGEXP '(?i)^DOCKERFILE$' THEN 1 ELSE 0 END AS dockerfile\r\n\t    FROM refs\r\n\t    JOIN commit_files \r\n\t    ON refs.commit_hash = commit_files.commit_hash \r\n\t    WHERE ref_name = \"refs/heads/master\" \r\n\t) q\r\n\tGROUP BY repository_id\r\n) q2\r",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:38"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 25, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 25,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-missing_files_summary-YqNVbLHqJ](id:25)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-missing_files_summary-YqNVbLHqJ",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 25,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              },
+              "column_name": "changelog",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 88,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 25,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              },
+              "column_name": "readme",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 89,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 25,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              },
+              "column_name": "notice",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 90,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 25,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              },
+              "column_name": "license",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 91,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 25,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              },
+              "column_name": "contributing",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 92,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 25,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              },
+              "column_name": "travis",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 93,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 25,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              },
+              "column_name": "ci",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 94,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 25,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "dockerfile",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 95,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              },
+              "id": 25,
+              "created_by_fk": null,
+              "table_id": 25,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "null",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:38"
+        },
+        "sql": "SELECT REPLACE(JSON_EXTRACT(SPLIT(committer_email, '@'), '$[1]'),'\"', '') as domain, COUNT(*) as n\nFROM commits\nWHERE committer_email LIKE '%%@%%' and committer_email NOT LIKE '%%@github.com'\nGROUP BY domain\nORDER BY n DESC",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:38"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 29, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 29,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-Untitled Query-tEO1Ih2Uu](id:29)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-Untitled Query-tEO1Ih2Uu",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 29,
+              "filterable": true,
+              "type": "STRING",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "domain",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 109,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 29,
+              "filterable": true,
+              "type": "LONGLONG",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "n",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 110,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "id": 30,
+              "created_by_fk": null,
+              "table_id": 29,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "null",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:39"
+        },
+        "sql": "SELECT committer_email, COUNT(*) as n\nFROM commits\nWHERE committer_email <> 'noreply@github.com'\nGROUP BY committer_email\nORDER BY n DESC",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:39"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 30, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 30,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-Untitled Query-JJ5b9O0Hc](id:30)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-Untitled Query-JJ5b9O0Hc",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 30,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:39"
+              },
+              "column_name": "committer_email",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 111,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:39"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 30,
+              "filterable": true,
+              "type": "LONGLONG",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:39"
+              },
+              "column_name": "n",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 112,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:39"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:39"
+              },
+              "id": 31,
+              "created_by_fk": null,
+              "table_id": 30,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:39"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "gitbase",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:36"
+        },
+        "sql": "SELECT repository_id, lang\r\nFROM (\r\n    SELECT\r\n        repository_id,\r\n        LANGUAGE(file_path) as lang\r\n    FROM refs\r\n    NATURAL JOIN commit_files\r\n    WHERE ref_name = 'HEAD'\r\n) AS q\r\nWHERE lang NOT IN ('', 'Ignore List')",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:36"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 21, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 21,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-head_repo_languages-FJfWO1kQ4](id:21)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-head_repo_languages-FJfWO1kQ4",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 21,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "repository_id",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 72,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 21,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "lang",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 73,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "id": 21,
+              "created_by_fk": null,
+              "table_id": 21,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "null",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:36"
+        },
+        "sql": "SELECT committer_email, COUNT(*) as n\nFROM commits\nWHERE committer_email <> 'noreply@github.com'\nGROUP BY committer_email\nORDER BY n DESC",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:36"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 22, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 22,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-Untitled Query-boJAIGUPS](id:22)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-Untitled Query-boJAIGUPS",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 22,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "committer_email",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 74,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 22,
+              "filterable": true,
+              "type": "LONGLONG",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "n",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 75,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "id": 22,
+              "created_by_fk": null,
+              "table_id": 22,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "null",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:36"
+        },
+        "sql": "SELECT commit_author_when,\nCOUNT(*) as n\nFROM ref_commits\nNATURAL JOIN commits\nWHERE ref_name = 'HEAD'\nGROUP BY commit_author_when\nORDER BY commit_author_when",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:36"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 18, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 18,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-Untitled Query-0scA3HaD5](id:18)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-Untitled Query-0scA3HaD5",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 18,
+              "filterable": true,
+              "type": "TIMESTAMP",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "commit_author_when",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 65,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 18,
+              "filterable": true,
+              "type": "LONGLONG",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "n",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 66,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "id": 18,
+              "created_by_fk": null,
+              "table_id": 18,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": null,
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:35"
+        },
+        "sql": "SELECT commit_author_name\nFROM commits\nGROUP BY commit_author_name\nORDER BY commit_author_name",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:35"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 14, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 14,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-Untitled Query-mW48VqXdL](id:14)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-Untitled Query-mW48VqXdL",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 14,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "column_name": "commit_author_name",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 57,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "id": 14,
+              "created_by_fk": null,
+              "table_id": 14,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": null,
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:07"
+        },
+        "sql": "select * from repositories",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:22:06"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 10, \"database_name\": \"gitbase\", \"import_time\": 1560871326}",
+        "id": 10,
+        "template_params": null,
+        "perm": "[gitbase].[gitbase.repositories](id:10)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "gitbase.repositories",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 10,
+              "filterable": false,
+              "type": "TEXT",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:39"
+              },
+              "column_name": "repository_id",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": false,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 47,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:07"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "COUNT(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": "count",
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:07"
+              },
+              "id": 10,
+              "created_by_fk": null,
+              "table_id": 10,
+              "d3format": null,
+              "description": null,
+              "verbose_name": "COUNT(*)",
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:07"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "null",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:36"
+        },
+        "sql": "SELECT repository_id, commit_author_when as date,\nCOUNT(*) as n\nFROM refs\nNATURAL JOIN commits\nWHERE ref_name LIKE 'refs/tags/v%.%.%'\nGROUP BY repository_id\nORDER BY repository_id",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:37"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 24, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 24,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-Untitled Query-LUNdDHhhu](id:24)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-Untitled Query-LUNdDHhhu",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 24,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              },
+              "column_name": "repository_id",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 85,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 24,
+              "filterable": true,
+              "type": "TIMESTAMP",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              },
+              "column_name": "date",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 86,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 24,
+              "filterable": true,
+              "type": "LONGLONG",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              },
+              "column_name": "n",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 87,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:37"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "id": 24,
+              "created_by_fk": null,
+              "table_id": 24,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "gitbase",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:38"
+        },
+        "sql": "SELECT \r\n    SUM(changelog != 0) / COUNT(changelog)  as changelog, \r\n    SUM(readme != 0)  / COUNT(changelog) as readme, \r\n    SUM(notice != 0)  / COUNT(changelog) as notice, \r\n    SUM(license != 0) / COUNT(changelog) as license,\r\n    SUM(contributing != 0) / COUNT(changelog) as contributing,\r\n    SUM(travis != 0) / COUNT(changelog) as travis, \r\n    SUM(ci != 0) / COUNT(changelog) as ci, \r\n    SUM(dockerfile != 0) / COUNT(changelog) as dockerfile \r\nFROM (\r\n    SELECT \r\n        SUM(changelog) as changelog, \r\n        SUM(readme) as readme, \r\n        SUM(notice) as notice, \r\n        SUM(license) as license,\r\n        SUM(contributing) as contributing,\r\n        SUM(travis) as travis,\r\n        SUM(ci) as ci,\r\n        SUM(dockerfile) as dockerfile\r\n    FROM (\r\n        SELECT \r\n            refs.repository_id, \r\n            CASE WHEN file_path REGEXP '(?i)^CHANGELOG(|\\.MD)' THEN 1 ELSE 0 END AS changelog,\r\n            CASE WHEN file_path REGEXP '(?i)^README(|\\.MD)' THEN 1 ELSE 0 END AS readme,\r\n            CASE WHEN file_path REGEXP '(?i)^NOTICE(|\\.MD)' THEN 1 ELSE 0 END AS notice,\r\n            CASE WHEN file_path REGEXP '(?i)^LICENSE(|\\.MD)' THEN 1 ELSE 0 END AS license,\r\n            CASE WHEN file_path REGEXP '(?i)^CONTRIBUTING(|\\.MD)' THEN 1 ELSE 0 END AS contributing,\r\n            CASE WHEN file_path REGEXP '(?i)^\\.TRAVIS\\.YML' THEN 1 ELSE 0 END AS travis,\r\n            CASE WHEN file_path REGEXP '(?i)^CI' THEN 1 ELSE 0 END AS ci,\r\n            CASE WHEN file_path REGEXP '(?i)^DOCKERFILE$' THEN 1 ELSE 0 END AS dockerfile\r\n        FROM refs\r\n        JOIN commit_files \r\n        ON refs.commit_hash = commit_files.commit_hash \r\n        WHERE ref_name = \"refs/heads/master\" \r\n    ) q\r\n    GROUP BY repository_id\r\n) q2",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:38"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 28, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 28,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-compliance_score-ReDkKHp6n](id:28)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-compliance_score-ReDkKHp6n",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 28,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "changelog",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 101,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 28,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "readme",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 102,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 28,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "notice",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 103,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 28,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "license",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 104,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 28,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "contributing",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 105,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 28,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "travis",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 106,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 28,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "ci",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 107,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 28,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "dockerfile",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 108,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "id": 28,
+              "created_by_fk": null,
+              "table_id": 28,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "changed_by_fk": null
+            }
+          },
+          {
+            "__SqlMetric__": {
+              "expression": "(changelog + 3 * readme + 3 * notice + 3 * license + contributing + travis + ci + Dockerfile) / 14.0",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "compliance",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "id": 29,
+              "created_by_fk": null,
+              "table_id": 28,
+              "d3format": null,
+              "description": null,
+              "verbose_name": "compliance",
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "gitbase",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:36"
+        },
+        "sql": "SELECT\r\n    repository_id,\r\n    commit_author_when,\r\n    CASE ARRAY_LENGTH(commit_parents) WHEN 0 THEN 'Commit' WHEN 1 THEN 'Commit' ELSE 'Merge' END AS commit_type\r\nFROM commits",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:36"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 20, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 20,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-commit_merges-8X2HBrQre](id:20)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-commit_merges-8X2HBrQre",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 20,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "repository_id",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 69,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 20,
+              "filterable": true,
+              "type": "TIMESTAMP",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "commit_author_when",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 70,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 20,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "commit_type",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 71,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "id": 20,
+              "created_by_fk": null,
+              "table_id": 20,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "null",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:35"
+        },
+        "sql": "SELECT repository_id, COUNT(*) as n\nFROM ref_commits\nWHERE ref_name = 'HEAD'\nGROUP BY repository_id\nORDER BY n DESC\nLIMIT 20",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:36"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 17, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 17,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-Untitled Query-rpq4L7GFr](id:17)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-Untitled Query-rpq4L7GFr",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 17,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "repository_id",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 63,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 17,
+              "filterable": true,
+              "type": "LONGLONG",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "n",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 64,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "id": 17,
+              "created_by_fk": null,
+              "table_id": 17,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "null",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:38"
+        },
+        "sql": "SELECT repository_id, COUNT(commit_author_name) as collaborators_count FROM (\nSELECT DISTINCT commit_author_name, repository_id\nFROM commits\n) q1\nGROUP BY repository_id\nORDER BY collaborators_count DESC",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:38"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 26, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 26,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-Untitled Query-CmGNVca6-](id:26)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-Untitled Query-CmGNVca6-",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 26,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "repository_id",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 96,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 26,
+              "filterable": true,
+              "type": "LONGLONG",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "collaborators_count",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 97,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "id": 26,
+              "created_by_fk": null,
+              "table_id": 26,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "null",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:35"
+        },
+        "sql": "SELECT REPLACE(JSON_EXTRACT(SPLIT(committer_email, '@'), '$[1]'),'\"', '') as domain, COUNT(*) as n\nFROM commits\nWHERE committer_email LIKE '%%@%%' and committer_email NOT LIKE '%%@github.com'\nGROUP BY domain\nORDER BY n DESC",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:35"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 13, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 13,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-Untitled Query-UnJl1GKQ8](id:13)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-Untitled Query-UnJl1GKQ8",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 13,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "column_name": "domain",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 55,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 13,
+              "filterable": true,
+              "type": "LONGLONG",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "column_name": "n",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 56,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "id": 13,
+              "created_by_fk": null,
+              "table_id": 13,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "null",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:38"
+        },
+        "sql": "SELECT repository_id as repo,\ncommit_author_when commit_date,\nCOUNT(*) as n\nFROM commits\nWHERE commit_author_when <= now()\nGROUP BY repo, commit_date\nORDER BY repo, commit_date",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:38"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 27, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 27,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-Untitled Query-Wfqa9oVcQ](id:27)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-Untitled Query-Wfqa9oVcQ",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 27,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "repo",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 98,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 27,
+              "filterable": true,
+              "type": "TIMESTAMP",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "commit_date",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 99,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 27,
+              "filterable": true,
+              "type": "LONGLONG",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "column_name": "n",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 100,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "id": 27,
+              "created_by_fk": null,
+              "table_id": 27,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:38"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "null",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:36"
+        },
+        "sql": "SELECT lang, SUM(n) as sum_n\nFROM (\nSELECT lang, SUM(lines) as n\nFROM (\nSELECT f.repository_id, LANGUAGE(cf.file_path, f.blob_content) as lang,\nARRAY_LENGTH(SPLIT(f.blob_content, '\\n')) as lines\nFROM files AS f\nNATURAL JOIN commit_files cf\nNATURAL JOIN refs\nWHERE ref_name = 'HEAD'\nAND file_path NOT LIKE 'vendor/%%'\n) AS t\nWHERE lang IS NOT NULL\nGROUP BY repository_id, lang\n) AS t\nGROUP by lang\nORDER BY n DESC",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:36"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 19, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 19,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-Untitled Query-ykYJeoJJn](id:19)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-Untitled Query-ykYJeoJJn",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 19,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "lang",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 67,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 19,
+              "filterable": true,
+              "type": "DOUBLE",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "sum_n",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 68,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "id": 19,
+              "created_by_fk": null,
+              "table_id": 19,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "null",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:35"
+        },
+        "sql": "SELECT lang, COUNT(*) as n\nFROM (\nSELECT LANGUAGE(cf.file_path, f.blob_content) as lang\nFROM files AS f\nNATURAL JOIN commit_files cf\nNATURAL JOIN refs\nWHERE ref_name = 'HEAD'\nAND file_path NOT LIKE 'vendor/%%'\n) AS t\nWHERE lang is not null\nGROUP BY lang\nORDER BY 2 DESC",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:35"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 16, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 16,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-Untitled Query-Kmw5frZ_b](id:16)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-Untitled Query-Kmw5frZ_b",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 16,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "column_name": "lang",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 61,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 16,
+              "filterable": true,
+              "type": "LONGLONG",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "column_name": "n",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 62,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "id": 16,
+              "created_by_fk": null,
+              "table_id": 16,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:35"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 1,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "gitbase",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:21:36"
+        },
+        "sql": "SELECT \r\n    repository_id, \r\n    CASE WHEN MAX(changelog) = 0 THEN 'missing' ELSE '' END as changelog, \r\n    CASE WHEN MAX(readme) = 0 THEN 'missing' ELSE '' END as readme, \r\n    CASE WHEN MAX(notice) = 0 THEN 'missing' ELSE '' END as notice, \r\n    CASE WHEN MAX(license) = 0 THEN 'missing' ELSE '' END as license,\r\n    CASE WHEN MAX(contributing) = 0 THEN 'missing' ELSE '' END as contributing,\r\n    CASE WHEN MAX(travis) = 0 THEN 'missing' ELSE '' END as travis, \r\n    CASE WHEN MAX(ci) = 0 THEN 'missing' ELSE '' END as ci, \r\n    CASE WHEN MAX(dockerfile) = 0 THEN 'missing' ELSE '' END as dockerfile\r\nFROM (\r\n    SELECT \r\n        refs.repository_id, \r\n        CASE WHEN file_path REGEXP '(?i)^CHANGELOG(|\\.MD)' THEN 1 ELSE 0 END AS changelog,\r\n        CASE WHEN file_path REGEXP '(?i)^README(|\\.MD)' THEN 1 ELSE 0 END AS readme,\r\n        CASE WHEN file_path REGEXP '(?i)^NOTICE(|\\.MD)' THEN 1 ELSE 0 END AS notice,\r\n        CASE WHEN file_path REGEXP '(?i)^LICENSE(|\\.MD)' THEN 1 ELSE 0 END AS license,\r\n        CASE WHEN file_path REGEXP '(?i)^CONTRIBUTING(|\\.MD)' THEN 1 ELSE 0 END AS contributing,\r\n        CASE WHEN file_path REGEXP '(?i)^\\.TRAVIS\\.YML' THEN 1 ELSE 0 END AS travis,\r\n        CASE WHEN file_path REGEXP '(?i)^CI' THEN 1 ELSE 0 END AS ci,\r\n        CASE WHEN file_path REGEXP '(?i)^DOCKERFILE$' THEN 1 ELSE 0 END AS dockerfile\r\n    FROM refs\r\n    JOIN commit_files \r\n    ON refs.commit_hash = commit_files.commit_hash \r\n    WHERE ref_name = \"refs/heads/master\" \r\n) q\r\nGROUP BY repository_id",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:21:36"
+        },
+        "is_sqllab_view": false,
+        "params": "{\"remote_id\": 23, \"database_name\": \"gitbase\", \"import_time\": 1560871295}",
+        "id": 23,
+        "template_params": "{}",
+        "perm": "[gitbase].[admin admin-missing_files-Y0yDW8RN6](id:23)",
+        "description": null,
+        "created_by_fk": null,
+        "table_name": "admin admin-missing_files-Y0yDW8RN6",
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 23,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "repository_id",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 76,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 23,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "changelog",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 77,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 23,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "readme",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 78,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 23,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "notice",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 79,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 23,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "license",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 80,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 23,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "contributing",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 81,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 23,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "travis",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 82,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 23,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "ci",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 83,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 23,
+              "filterable": true,
+              "type": "BLOB",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "column_name": "dockerfile",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": null,
+              "id": 84,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "id": 23,
+              "created_by_fk": null,
+              "table_id": 23,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:21:36"
+              },
+              "changed_by_fk": null
+            }
+          }
+        ],
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "perm": "[gitbase].(id:1)",
+            "allow_run_async": true,
+            "id": 1,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_dml": true,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "force_ctas_schema": null,
+            "password": null,
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:06"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        }
+      }
+    }
+  ]
 }

--- a/srcd/dashboards/metadata/collaboration.json
+++ b/srcd/dashboards/metadata/collaboration.json
@@ -1,0 +1,1843 @@
+{
+  "dashboards": [
+    {
+      "__Dashboard__": {
+        "position_json": "{\"CHART-3F9wGa1nVe\":{\"children\":[],\"id\":\"CHART-3F9wGa1nVe\",\"meta\":{\"chartId\":23,\"height\":49,\"sliceName\":\"Most Active Repositories\",\"width\":12},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-Ixfutv2rRl\"],\"type\":\"CHART\"},\"CHART-5FbG_o7Awy\":{\"children\":[],\"id\":\"CHART-5FbG_o7Awy\",\"meta\":{\"chartId\":27,\"height\":48,\"sliceName\":\"Time to Merge Change Over Time\",\"width\":8},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-Re8r7jF5U\"],\"type\":\"CHART\"},\"CHART-CxhPIuq8WU\":{\"children\":[],\"id\":\"CHART-CxhPIuq8WU\",\"meta\":{\"chartId\":24,\"height\":50,\"sliceName\":\"Breakdown by Pull Request Outcome\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-Re8r7jF5U\"],\"type\":\"CHART\"},\"CHART-H_hOSBOPpo\":{\"children\":[],\"id\":\"CHART-H_hOSBOPpo\",\"meta\":{\"chartId\":28,\"height\":81,\"sliceName\":\"Pull Requests Workflow\",\"width\":12},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-vMR1OCiTh\"],\"type\":\"CHART\"},\"CHART-P3ebofatqz\":{\"children\":[],\"id\":\"CHART-P3ebofatqz\",\"meta\":{\"chartId\":22,\"height\":45,\"sliceName\":\"# of pull requests created\",\"width\":12},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-FTyrflnSnH\"],\"type\":\"CHART\"},\"CHART-VN6sVVMmGQ\":{\"children\":[],\"id\":\"CHART-VN6sVVMmGQ\",\"meta\":{\"chartId\":25,\"height\":50,\"sliceName\":\"Avg. Time to Merge\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-BFazKQCAx\"],\"type\":\"CHART\"},\"CHART-oaC094q3qs\":{\"children\":[],\"id\":\"CHART-oaC094q3qs\",\"meta\":{\"chartId\":21,\"height\":50,\"sliceName\":\"Not Merged Pull Requests\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-BFazKQCAx\"],\"type\":\"CHART\"},\"CHART-v08M9Dd851\":{\"children\":[],\"id\":\"CHART-v08M9Dd851\",\"meta\":{\"chartId\":26,\"height\":50,\"sliceName\":\"Median Time to Merge\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-BFazKQCAx\"],\"type\":\"CHART\"},\"DASHBOARD_VERSION_KEY\":\"v2\",\"GRID_ID\":{\"children\":[\"ROW-BFazKQCAx\",\"ROW-Ixfutv2rRl\",\"ROW-FTyrflnSnH\",\"ROW-Re8r7jF5U\",\"ROW-vMR1OCiTh\"],\"id\":\"GRID_ID\",\"parents\":[\"ROOT_ID\"],\"type\":\"GRID\"},\"HEADER_ID\":{\"id\":\"HEADER_ID\",\"meta\":{\"text\":\"Collaboration\"},\"type\":\"HEADER\"},\"ROOT_ID\":{\"children\":[\"GRID_ID\"],\"id\":\"ROOT_ID\",\"type\":\"ROOT\"},\"ROW-BFazKQCAx\":{\"children\":[\"CHART-oaC094q3qs\",\"CHART-VN6sVVMmGQ\",\"CHART-v08M9Dd851\"],\"id\":\"ROW-BFazKQCAx\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-FTyrflnSnH\":{\"children\":[\"CHART-P3ebofatqz\"],\"id\":\"ROW-FTyrflnSnH\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-Ixfutv2rRl\":{\"children\":[\"CHART-3F9wGa1nVe\"],\"id\":\"ROW-Ixfutv2rRl\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-Re8r7jF5U\":{\"children\":[\"CHART-5FbG_o7Awy\",\"CHART-CxhPIuq8WU\"],\"id\":\"ROW-Re8r7jF5U\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-vMR1OCiTh\":{\"children\":[\"CHART-H_hOSBOPpo\"],\"id\":\"ROW-vMR1OCiTh\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"}}",
+        "id": 3,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:23:12"
+        },
+        "created_by_fk": 1,
+        "json_metadata": "{\"filter_immune_slices\": [], \"timed_refresh_immune_slices\": [], \"filter_immune_slice_fields\": {}, \"expanded_slices\": {}, \"refresh_frequency\": 0, \"default_filters\": \"{}\", \"remote_id\": 3}",
+        "description": null,
+        "dashboard_title": "Collaboration",
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:59:25"
+        },
+        "changed_by_fk": 1,
+        "slug": null,
+        "css": "",
+        "slices": [
+          {
+            "__Slice__": {
+              "id": 21,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:24:50"
+              },
+              "created_by_fk": 1,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "big_number_total",
+              "datasource_type": "table",
+              "slice_name": "Not Merged Pull Requests",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[None].[pr_status-8jUyYteDu](id:31)",
+              "params": "{\"adhoc_filters\": [], \"datasource\": \"31__table\", \"granularity_sqla\": null, \"metric\": {\"aggregate\": null, \"column\": null, \"expressionType\": \"SQL\", \"fromFormData\": true, \"hasCustomLabel\": false, \"label\": \"SUM(closed)*1.0/(SUM(merged)+SUM(closed))\", \"optionName\": \"metric_0q0ckjqq7qoa_9awq4k5lq6v\", \"sqlExpression\": \"SUM(closed)*1.0/(SUM(merged)+SUM(closed))\"}, \"slice_id\": 21, \"time_grain_sqla\": \"P1D\", \"time_range\": \"No filter\", \"viz_type\": \"big_number_total\", \"y_axis_format\": \",.1%\", \"remote_id\": 21, \"datasource_name\": \"public.pr_status-8jUyYteDu\", \"schema\": \"public.pr_status-8jUyYteDu\", \"database_name\": \"metadata\"}",
+              "datasource_name": "public.pr_status-8jUyYteDu",
+              "datasource_id": 31,
+              "owners": [
+                {
+                  "__User__": {
+                    "created_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "last_name": "admin",
+                    "changed_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "username": "admin",
+                    "created_by_fk": null,
+                    "password": "pbkdf2:sha256:50000$Z1vpEOs4$34494050d3532e8df40994116a0b2c749ded558589592396047e70556b6ea6b4",
+                    "changed_by_fk": null,
+                    "active": true,
+                    "email": "admin@example.com",
+                    "last_login": null,
+                    "id": 1,
+                    "login_count": null,
+                    "first_name": "admin",
+                    "fail_login_count": null
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 22,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:44:18"
+              },
+              "created_by_fk": 1,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "area",
+              "datasource_type": "table",
+              "slice_name": "# of pull requests created",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[None].[pr_created_at-RVVRcORPF](id:32)",
+              "params": "{\"adhoc_filters\": [], \"annotation_layers\": [], \"bottom_margin\": \"auto\", \"color_scheme\": \"bnbColors\", \"comparison_type\": \"values\", \"contribution\": false, \"datasource\": \"32__table\", \"granularity_sqla\": \"created_at\", \"groupby\": [], \"line_interpolation\": \"linear\", \"metrics\": [\"count\"], \"order_desc\": true, \"resample_fillmethod\": null, \"resample_how\": null, \"resample_rule\": null, \"rich_tooltip\": true, \"rolling_type\": \"None\", \"row_limit\": 1000, \"show_brush\": \"auto\", \"show_controls\": false, \"show_legend\": true, \"slice_id\": 22, \"stacked_style\": \"stack\", \"time_grain_sqla\": \"P1M\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"area\", \"x_axis_format\": \"smart_date\", \"x_axis_label\": \"\", \"x_axis_showminmax\": false, \"x_ticks_layout\": \"auto\", \"y_axis_bounds\": [null, null], \"y_axis_format\": \".3s\", \"y_log_scale\": false, \"remote_id\": 22, \"datasource_name\": \"public.pr_created_at-RVVRcORPF\", \"schema\": \"public.pr_created_at-RVVRcORPF\", \"database_name\": \"metadata\"}",
+              "datasource_name": "public.pr_created_at-RVVRcORPF",
+              "datasource_id": 32,
+              "owners": [
+                {
+                  "__User__": {
+                    "created_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "last_name": "admin",
+                    "changed_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "username": "admin",
+                    "created_by_fk": null,
+                    "password": "pbkdf2:sha256:50000$Z1vpEOs4$34494050d3532e8df40994116a0b2c749ded558589592396047e70556b6ea6b4",
+                    "changed_by_fk": null,
+                    "active": true,
+                    "email": "admin@example.com",
+                    "last_login": null,
+                    "id": 1,
+                    "login_count": null,
+                    "first_name": "admin",
+                    "fail_login_count": null
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 23,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:49:08"
+              },
+              "created_by_fk": 1,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "dist_bar",
+              "datasource_type": "table",
+              "slice_name": "Most Active Repositories",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[None].[admin admin-pr_dates-4xBftRm5b](id:33)",
+              "params": "{\"adhoc_filters\": [], \"bar_stacked\": true, \"bottom_margin\": \"auto\", \"color_scheme\": \"bnbColors\", \"columns\": [], \"contribution\": false, \"datasource\": \"33__table\", \"granularity_sqla\": \"created_at\", \"groupby\": [\"repository\"], \"metrics\": [{\"aggregate\": \"COUNT\", \"column\": {\"column_name\": \"merged_at\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 121, \"is_dttm\": true, \"optionName\": \"_col_merged_at\", \"python_date_format\": null, \"type\": \"DATETIME\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": true, \"hasCustomLabel\": true, \"label\": \"Merged\", \"optionName\": \"metric_jxumwoerhhf_6h4frowknyp\", \"sqlExpression\": null}, {\"aggregate\": null, \"column\": null, \"expressionType\": \"SQL\", \"fromFormData\": true, \"hasCustomLabel\": true, \"label\": \"Closed\", \"optionName\": \"metric_ub9fmazo6sg_kfzd36b2uv\", \"sqlExpression\": \"COUNT(closed_at)-COUNT(merged_at)\"}, {\"aggregate\": null, \"column\": null, \"expressionType\": \"SQL\", \"fromFormData\": true, \"hasCustomLabel\": true, \"label\": \"Open\", \"optionName\": \"metric_0bzo6iod7vl6_oxnj5hz10m\", \"sqlExpression\": \"COUNT(*)-COUNT(closed_at)\"}], \"order_bars\": false, \"reduce_x_ticks\": false, \"row_limit\": 1000, \"show_bar_value\": false, \"show_controls\": false, \"show_legend\": true, \"slice_id\": 23, \"time_grain_sqla\": \"P1D\", \"time_range\": \"Last 30 days\", \"viz_type\": \"dist_bar\", \"x_axis_label\": \"\", \"x_ticks_layout\": \"auto\", \"y_axis_format\": \".3s\", \"y_axis_label\": \"\", \"remote_id\": 23, \"datasource_name\": \"public.admin admin-pr_dates-4xBftRm5b\", \"schema\": \"public.admin admin-pr_dates-4xBftRm5b\", \"database_name\": \"metadata\"}",
+              "datasource_name": "public.admin admin-pr_dates-4xBftRm5b",
+              "datasource_id": 33,
+              "owners": [
+                {
+                  "__User__": {
+                    "created_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "last_name": "admin",
+                    "changed_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "username": "admin",
+                    "created_by_fk": null,
+                    "password": "pbkdf2:sha256:50000$Z1vpEOs4$34494050d3532e8df40994116a0b2c749ded558589592396047e70556b6ea6b4",
+                    "changed_by_fk": null,
+                    "active": true,
+                    "email": "admin@example.com",
+                    "last_login": null,
+                    "id": 1,
+                    "login_count": null,
+                    "first_name": "admin",
+                    "fail_login_count": null
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 24,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:50:21"
+              },
+              "created_by_fk": 1,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "sunburst",
+              "datasource_type": "table",
+              "slice_name": "Breakdown by Pull Request Outcome",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[None].[pr_resolution-c5KRWDa_V](id:34)",
+              "params": "{\"adhoc_filters\": [], \"color_scheme\": \"bnbColors\", \"datasource\": \"34__table\", \"granularity_sqla\": null, \"groupby\": [\"repository\", \"resolution_type\"], \"metric\": \"count\", \"row_limit\": 1000, \"secondary_metric\": null, \"slice_id\": 24, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"sunburst\", \"remote_id\": 24, \"datasource_name\": \"public.pr_resolution-c5KRWDa_V\", \"schema\": \"public.pr_resolution-c5KRWDa_V\", \"database_name\": \"metadata\"}",
+              "datasource_name": "public.pr_resolution-c5KRWDa_V",
+              "datasource_id": 34,
+              "owners": [
+                {
+                  "__User__": {
+                    "created_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "last_name": "admin",
+                    "changed_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "username": "admin",
+                    "created_by_fk": null,
+                    "password": "pbkdf2:sha256:50000$Z1vpEOs4$34494050d3532e8df40994116a0b2c749ded558589592396047e70556b6ea6b4",
+                    "changed_by_fk": null,
+                    "active": true,
+                    "email": "admin@example.com",
+                    "last_login": null,
+                    "id": 1,
+                    "login_count": null,
+                    "first_name": "admin",
+                    "fail_login_count": null
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 25,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:51:53"
+              },
+              "created_by_fk": 1,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "big_number_total",
+              "datasource_type": "table",
+              "slice_name": "Avg. Time to Merge",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[None].[pr_time_to_merge-ejLXE2oaX](id:35)",
+              "params": "{\"adhoc_filters\": [], \"datasource\": \"35__table\", \"granularity_sqla\": \"created_at\", \"metric\": {\"aggregate\": \"AVG\", \"column\": {\"column_name\": \"days\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 129, \"is_dttm\": false, \"optionName\": \"_col_days\", \"python_date_format\": null, \"type\": \"FLOAT\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": false, \"hasCustomLabel\": false, \"label\": \"AVG(days)\", \"optionName\": \"metric_qd4g8quql4_o3a11vjb6ci\", \"sqlExpression\": null}, \"slice_id\": 25, \"subheader\": \"Average number of days before merge\", \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"big_number_total\", \"y_axis_format\": \".3s\", \"remote_id\": 25, \"datasource_name\": \"public.pr_time_to_merge-ejLXE2oaX\", \"schema\": \"public.pr_time_to_merge-ejLXE2oaX\", \"database_name\": \"metadata\"}",
+              "datasource_name": "public.pr_time_to_merge-ejLXE2oaX",
+              "datasource_id": 35,
+              "owners": [
+                {
+                  "__User__": {
+                    "created_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "last_name": "admin",
+                    "changed_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "username": "admin",
+                    "created_by_fk": null,
+                    "password": "pbkdf2:sha256:50000$Z1vpEOs4$34494050d3532e8df40994116a0b2c749ded558589592396047e70556b6ea6b4",
+                    "changed_by_fk": null,
+                    "active": true,
+                    "email": "admin@example.com",
+                    "last_login": null,
+                    "id": 1,
+                    "login_count": null,
+                    "first_name": "admin",
+                    "fail_login_count": null
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 26,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:53:19"
+              },
+              "created_by_fk": 1,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "big_number_total",
+              "datasource_type": "table",
+              "slice_name": "Median Time to Merge",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[None].[pr_time_to_merge_median-_4s5FrIrI](id:36)",
+              "params": "{\"adhoc_filters\": [], \"datasource\": \"36__table\", \"granularity_sqla\": \"created_at\", \"metric\": {\"aggregate\": null, \"column\": null, \"expressionType\": \"SQL\", \"fromFormData\": true, \"hasCustomLabel\": false, \"label\": \"percentile_disc(0.5) WITHIN GROUP (ORDER...\", \"optionName\": \"metric_gzz9981bhx4_681hslzi1z\", \"sqlExpression\": \"percentile_disc(0.5) WITHIN GROUP (ORDER BY extract(epoch from time_to_merge) / 3600.00)\"}, \"slice_id\": 26, \"subheader\": \"Median number of hours before merge\", \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"big_number_total\", \"y_axis_format\": \".3s\", \"remote_id\": 26, \"datasource_name\": \"public.pr_time_to_merge_median-_4s5FrIrI\", \"schema\": \"public.pr_time_to_merge_median-_4s5FrIrI\", \"database_name\": \"metadata\"}",
+              "datasource_name": "public.pr_time_to_merge_median-_4s5FrIrI",
+              "datasource_id": 36,
+              "owners": [
+                {
+                  "__User__": {
+                    "created_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "last_name": "admin",
+                    "changed_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "username": "admin",
+                    "created_by_fk": null,
+                    "password": "pbkdf2:sha256:50000$Z1vpEOs4$34494050d3532e8df40994116a0b2c749ded558589592396047e70556b6ea6b4",
+                    "changed_by_fk": null,
+                    "active": true,
+                    "email": "admin@example.com",
+                    "last_login": null,
+                    "id": 1,
+                    "login_count": null,
+                    "first_name": "admin",
+                    "fail_login_count": null
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 27,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:55:21"
+              },
+              "created_by_fk": 1,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "line",
+              "datasource_type": "table",
+              "slice_name": "Time to Merge Change Over Time",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[None].[admin admin-pr_by_days-XSb1QtdX4](id:37)",
+              "params": "{\"adhoc_filters\": [], \"annotation_layers\": [], \"bottom_margin\": \"auto\", \"color_scheme\": \"bnbColors\", \"comparison_type\": \"values\", \"contribution\": false, \"datasource\": \"37__table\", \"granularity_sqla\": \"created_at\", \"groupby\": [], \"left_margin\": \"auto\", \"line_interpolation\": \"cardinal\", \"metrics\": [{\"aggregate\": \"AVG\", \"column\": {\"column_name\": \"days\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 138, \"is_dttm\": false, \"optionName\": \"_col_days\", \"python_date_format\": null, \"type\": \"FLOAT\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": true, \"hasCustomLabel\": true, \"label\": \"Average\", \"optionName\": \"metric_v6tqzr5nihp_l7qb802z3jo\", \"sqlExpression\": null}], \"order_desc\": true, \"resample_fillmethod\": null, \"resample_how\": null, \"resample_rule\": null, \"rich_tooltip\": true, \"rolling_type\": \"None\", \"row_limit\": 1000, \"send_time_range\": false, \"show_brush\": \"auto\", \"show_legend\": true, \"show_markers\": true, \"slice_id\": 27, \"time_grain_sqla\": \"P1M\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"line\", \"x_axis_format\": \"smart_date\", \"x_axis_label\": \"\", \"x_axis_showminmax\": false, \"x_ticks_layout\": \"auto\", \"y_axis_bounds\": [null, null], \"y_axis_format\": \".3s\", \"y_axis_label\": \"avg. # of days\", \"y_axis_showminmax\": false, \"y_log_scale\": false, \"remote_id\": 27, \"datasource_name\": \"public.admin admin-pr_by_days-XSb1QtdX4\", \"schema\": \"public.admin admin-pr_by_days-XSb1QtdX4\", \"database_name\": \"metadata\"}",
+              "datasource_name": "public.admin admin-pr_by_days-XSb1QtdX4",
+              "datasource_id": 37,
+              "owners": [
+                {
+                  "__User__": {
+                    "created_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "last_name": "admin",
+                    "changed_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "username": "admin",
+                    "created_by_fk": null,
+                    "password": "pbkdf2:sha256:50000$Z1vpEOs4$34494050d3532e8df40994116a0b2c749ded558589592396047e70556b6ea6b4",
+                    "changed_by_fk": null,
+                    "active": true,
+                    "email": "admin@example.com",
+                    "last_login": null,
+                    "id": 1,
+                    "login_count": null,
+                    "first_name": "admin",
+                    "fail_login_count": null
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "__Slice__": {
+              "id": 28,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:57:16"
+              },
+              "created_by_fk": 1,
+              "cache_timeout": null,
+              "description": null,
+              "viz_type": "event_flow",
+              "datasource_type": "table",
+              "slice_name": "Pull Requests Workflow",
+              "changed_on": {
+                "__datetime__": "2019-06-18T16:00:01"
+              },
+              "changed_by_fk": null,
+              "perm": "[None].[pr_workflow-6tUyZn8RC](id:38)",
+              "params": "{\"adhoc_filters\": [], \"all_columns\": [\"repository\", \"number\", \"label\", \"event\", \"time\"], \"all_columns_x\": \"event\", \"datasource\": \"38__table\", \"entity\": \"label\", \"granularity_sqla\": \"time\", \"min_leaf_node_event_count\": 1, \"order_by_entity\": true, \"row_limit\": 10000, \"slice_id\": 28, \"time_grain_sqla\": \"PT1S\", \"time_range\": \"Last 30 days\", \"viz_type\": \"event_flow\", \"remote_id\": 28, \"datasource_name\": \"public.pr_workflow-6tUyZn8RC\", \"schema\": \"public.pr_workflow-6tUyZn8RC\", \"database_name\": \"metadata\"}",
+              "datasource_name": "public.pr_workflow-6tUyZn8RC",
+              "datasource_id": 38,
+              "owners": [
+                {
+                  "__User__": {
+                    "created_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "last_name": "admin",
+                    "changed_on": {
+                      "__datetime__": "2019-06-18T15:21:20"
+                    },
+                    "username": "admin",
+                    "created_by_fk": null,
+                    "password": "pbkdf2:sha256:50000$Z1vpEOs4$34494050d3532e8df40994116a0b2c749ded558589592396047e70556b6ea6b4",
+                    "changed_by_fk": null,
+                    "active": true,
+                    "email": "admin@example.com",
+                    "last_login": null,
+                    "id": 1,
+                    "login_count": null,
+                    "first_name": "admin",
+                    "fail_login_count": null
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "datasources": [
+    {
+      "__SqlaTable__": {
+        "database_id": 2,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "public",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:46:57"
+        },
+        "sql": "SELECT CONCAT(repository_owner, '/', repository_name) AS repository, created_at, merged_at, closed_at \nFROM pull_requests",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:46:57"
+        },
+        "is_sqllab_view": true,
+        "params": "{\"remote_id\": 33, \"database_name\": \"metadata\"}",
+        "id": 33,
+        "template_params": "{}",
+        "perm": "[None].[admin admin-pr_dates-4xBftRm5b](id:33)",
+        "description": null,
+        "created_by_fk": 1,
+        "table_name": "admin admin-pr_dates-4xBftRm5b",
+        "default_endpoint": null,
+        "changed_by_fk": 1,
+        "main_dttm_col": null,
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "perm": "[metadata].(id:2)",
+            "allow_run_async": false,
+            "id": 2,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "metadata",
+            "changed_by_fk": null,
+            "allow_dml": false,
+            "sqlalchemy_uri": "postgresql://metadata:XXXXXXXXXX@metadatadb:5432/metadata",
+            "force_ctas_schema": null,
+            "password": "metadata",
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        },
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 33,
+              "filterable": true,
+              "type": "STRING",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:46:57"
+              },
+              "column_name": "repository",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 119,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:46:57"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 33,
+              "filterable": true,
+              "type": "DATETIME",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:46:57"
+              },
+              "column_name": "created_at",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 120,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:46:57"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 33,
+              "filterable": true,
+              "type": "DATETIME",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:46:57"
+              },
+              "column_name": "merged_at",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 121,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:46:57"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 33,
+              "filterable": true,
+              "type": "DATETIME",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:46:57"
+              },
+              "column_name": "closed_at",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 122,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:46:57"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:46:57"
+              },
+              "id": 34,
+              "created_by_fk": 1,
+              "table_id": 33,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:46:57"
+              },
+              "changed_by_fk": 1
+            }
+          }
+        ]
+      }
+    },
+
+    {
+      "__SqlaTable__": {
+        "database_id": 2,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "public",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:53:55"
+        },
+        "sql": "SELECT\r\n    CONCAT(repository_owner, '/', repository_name) AS repository,\r\n    created_at,\r\n    merged_at, \r\n    extract(epoch from (merged_at - created_at)) / (3600.00 *24) as days\r\nFROM pull_requests \r\nWHERE merged_at IS NOT NULL",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:53:55"
+        },
+        "is_sqllab_view": true,
+        "params": "{\"remote_id\": 37, \"database_name\": \"metadata\"}",
+        "id": 37,
+        "template_params": "{}",
+        "perm": "[None].[admin admin-pr_by_days-XSb1QtdX4](id:37)",
+        "description": null,
+        "created_by_fk": 1,
+        "table_name": "admin admin-pr_by_days-XSb1QtdX4",
+        "default_endpoint": null,
+        "changed_by_fk": 1,
+        "main_dttm_col": null,
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "perm": "[metadata].(id:2)",
+            "allow_run_async": false,
+            "id": 2,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "metadata",
+            "changed_by_fk": null,
+            "allow_dml": false,
+            "sqlalchemy_uri": "postgresql://metadata:XXXXXXXXXX@metadatadb:5432/metadata",
+            "force_ctas_schema": null,
+            "password": "metadata",
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        },
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 37,
+              "filterable": true,
+              "type": "STRING",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:53:55"
+              },
+              "column_name": "repository",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 135,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:53:55"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 37,
+              "filterable": true,
+              "type": "DATETIME",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:53:55"
+              },
+              "column_name": "created_at",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 136,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:53:55"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 37,
+              "filterable": true,
+              "type": "DATETIME",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:53:55"
+              },
+              "column_name": "merged_at",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 137,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:53:55"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 37,
+              "filterable": true,
+              "type": "FLOAT",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:53:55"
+              },
+              "column_name": "days",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 138,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:53:55"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:53:55"
+              },
+              "id": 38,
+              "created_by_fk": 1,
+              "table_id": 37,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:53:55"
+              },
+              "changed_by_fk": 1
+            }
+          }
+        ]
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 2,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "public",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:55:44"
+        },
+        "sql": "SELECT\n    repository,\n    number,\n    CONCAT(repository, '/pull/', number) AS label,\n    event,\n    time\n    FROM (\n        SELECT\n        CONCAT(repository_owner, '/', repository_name) AS repository,\n        number,\n        created_at AS created_datetime,\n        merged_at AS merged_datetime,\n        CASE\n            WHEN merged_at IS NOT NULL THEN NULL\n            ELSE closed_at\n        END AS closed_datetime,\n        closed_at,\n        merged_at\n        FROM pull_requests) t\n    JOIN LATERAL (\n        VALUES('created', t.created_datetime), ('closed', t.closed_datetime), ('merged', t.merged_datetime)) s(event, time) ON TRUE",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:55:44"
+        },
+        "is_sqllab_view": true,
+        "params": "{\"remote_id\": 38, \"database_name\": \"metadata\"}",
+        "id": 38,
+        "template_params": "{}",
+        "perm": "[None].[pr_workflow-6tUyZn8RC](id:38)",
+        "description": null,
+        "created_by_fk": 1,
+        "table_name": "pr_workflow-6tUyZn8RC",
+        "default_endpoint": null,
+        "changed_by_fk": 1,
+        "main_dttm_col": null,
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "perm": "[metadata].(id:2)",
+            "allow_run_async": false,
+            "id": 2,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "metadata",
+            "changed_by_fk": null,
+            "allow_dml": false,
+            "sqlalchemy_uri": "postgresql://metadata:XXXXXXXXXX@metadatadb:5432/metadata",
+            "force_ctas_schema": null,
+            "password": "metadata",
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        },
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 38,
+              "filterable": true,
+              "type": "STRING",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:55:44"
+              },
+              "column_name": "repository",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 139,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:55:44"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 38,
+              "filterable": true,
+              "type": "INT",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:55:44"
+              },
+              "column_name": "number",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 140,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:55:44"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 38,
+              "filterable": true,
+              "type": "STRING",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:55:44"
+              },
+              "column_name": "label",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 141,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:55:44"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 38,
+              "filterable": true,
+              "type": "STRING",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:55:44"
+              },
+              "column_name": "event",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 142,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:55:44"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 38,
+              "filterable": true,
+              "type": "DATETIME",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:55:44"
+              },
+              "column_name": "time",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 143,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:55:44"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:55:44"
+              },
+              "id": 39,
+              "created_by_fk": 1,
+              "table_id": 38,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:55:44"
+              },
+              "changed_by_fk": 1
+            }
+          }
+        ]
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 2,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "public",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:43:07"
+        },
+        "sql": "SELECT id, created_at, to_char(date_trunc('month', created_at), 'YYYY-MM')\nFROM pull_requests",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:43:07"
+        },
+        "is_sqllab_view": true,
+        "params": "{\"remote_id\": 32, \"database_name\": \"metadata\"}",
+        "id": 32,
+        "template_params": "{}",
+        "perm": "[None].[pr_created_at-RVVRcORPF](id:32)",
+        "description": null,
+        "created_by_fk": 1,
+        "table_name": "pr_created_at-RVVRcORPF",
+        "default_endpoint": null,
+        "changed_by_fk": 1,
+        "main_dttm_col": null,
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "perm": "[metadata].(id:2)",
+            "allow_run_async": false,
+            "id": 2,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "metadata",
+            "changed_by_fk": null,
+            "allow_dml": false,
+            "sqlalchemy_uri": "postgresql://metadata:XXXXXXXXXX@metadatadb:5432/metadata",
+            "force_ctas_schema": null,
+            "password": "metadata",
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        },
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 32,
+              "filterable": true,
+              "type": "INT",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:43:07"
+              },
+              "column_name": "id",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 116,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:43:07"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 32,
+              "filterable": true,
+              "type": "DATETIME",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:43:07"
+              },
+              "column_name": "created_at",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 117,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:43:07"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 32,
+              "filterable": true,
+              "type": "STRING",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:43:07"
+              },
+              "column_name": "to_char",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 118,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:43:07"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:43:07"
+              },
+              "id": 33,
+              "created_by_fk": 1,
+              "table_id": 32,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:43:07"
+              },
+              "changed_by_fk": 1
+            }
+          }
+        ]
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 2,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "public",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:52:34"
+        },
+        "sql": "SELECT id, CONCAT(repository_owner, '/', repository_name) AS repository, created_at, merged_at, merged_at - created_at as time_to_merge\r\nFROM pull_requests \r\nWHERE merged_at IS NOT NULL",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:52:34"
+        },
+        "is_sqllab_view": true,
+        "params": "{\"remote_id\": 36, \"database_name\": \"metadata\"}",
+        "id": 36,
+        "template_params": "{}",
+        "perm": "[None].[pr_time_to_merge_median-_4s5FrIrI](id:36)",
+        "description": null,
+        "created_by_fk": 1,
+        "table_name": "pr_time_to_merge_median-_4s5FrIrI",
+        "default_endpoint": null,
+        "changed_by_fk": 1,
+        "main_dttm_col": null,
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "perm": "[metadata].(id:2)",
+            "allow_run_async": false,
+            "id": 2,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "metadata",
+            "changed_by_fk": null,
+            "allow_dml": false,
+            "sqlalchemy_uri": "postgresql://metadata:XXXXXXXXXX@metadatadb:5432/metadata",
+            "force_ctas_schema": null,
+            "password": "metadata",
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        },
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 36,
+              "filterable": true,
+              "type": "INT",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:52:35"
+              },
+              "column_name": "id",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 130,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:52:35"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 36,
+              "filterable": true,
+              "type": "STRING",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:52:35"
+              },
+              "column_name": "repository",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 131,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:52:35"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 36,
+              "filterable": true,
+              "type": "DATETIME",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:52:35"
+              },
+              "column_name": "created_at",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 132,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:52:35"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 36,
+              "filterable": true,
+              "type": "DATETIME",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:52:35"
+              },
+              "column_name": "merged_at",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 133,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:52:35"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 36,
+              "filterable": true,
+              "type": null,
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:52:35"
+              },
+              "column_name": "time_to_merge",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 134,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:52:35"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:52:35"
+              },
+              "id": 37,
+              "created_by_fk": 1,
+              "table_id": 36,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:52:35"
+              },
+              "changed_by_fk": 1
+            }
+          }
+        ]
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 2,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "public",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:49:45"
+        },
+        "sql": "SELECT CONCAT(repository_owner, '/', repository_name) AS repository,\n    CASE WHEN merged_at IS NOT NULL THEN 'merged'\n        WHEN closed_at IS NOT NULL THEN 'closed'\n    END AS resolution_type\nFROM pull_requests\nWHERE state <> 'open'",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:49:45"
+        },
+        "is_sqllab_view": true,
+        "params": "{\"remote_id\": 34, \"database_name\": \"metadata\"}",
+        "id": 34,
+        "template_params": "{}",
+        "perm": "[None].[pr_resolution-c5KRWDa_V](id:34)",
+        "description": null,
+        "created_by_fk": 1,
+        "table_name": "pr_resolution-c5KRWDa_V",
+        "default_endpoint": null,
+        "changed_by_fk": 1,
+        "main_dttm_col": null,
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "perm": "[metadata].(id:2)",
+            "allow_run_async": false,
+            "id": 2,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "metadata",
+            "changed_by_fk": null,
+            "allow_dml": false,
+            "sqlalchemy_uri": "postgresql://metadata:XXXXXXXXXX@metadatadb:5432/metadata",
+            "force_ctas_schema": null,
+            "password": "metadata",
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        },
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 34,
+              "filterable": true,
+              "type": "STRING",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:49:45"
+              },
+              "column_name": "repository",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 123,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:49:45"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 34,
+              "filterable": true,
+              "type": "STRING",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:49:45"
+              },
+              "column_name": "resolution_type",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 124,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:49:45"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:49:45"
+              },
+              "id": 35,
+              "created_by_fk": 1,
+              "table_id": 34,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:49:45"
+              },
+              "changed_by_fk": 1
+            }
+          }
+        ]
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 2,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "public",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:51:05"
+        },
+        "sql": "SELECT\r\n    id,\r\n    CONCAT(repository_owner, '/', repository_name) AS repository,\r\n    created_at,\r\n    merged_at, \r\n    extract(epoch from (merged_at - created_at)) / (3600.00 *24) as days\r\nFROM pull_requests \r\nWHERE merged_at IS NOT NULL",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:51:05"
+        },
+        "is_sqllab_view": true,
+        "params": "{\"remote_id\": 35, \"database_name\": \"metadata\"}",
+        "id": 35,
+        "template_params": "{}",
+        "perm": "[None].[pr_time_to_merge-ejLXE2oaX](id:35)",
+        "description": null,
+        "created_by_fk": 1,
+        "table_name": "pr_time_to_merge-ejLXE2oaX",
+        "default_endpoint": null,
+        "changed_by_fk": 1,
+        "main_dttm_col": null,
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "perm": "[metadata].(id:2)",
+            "allow_run_async": false,
+            "id": 2,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "metadata",
+            "changed_by_fk": null,
+            "allow_dml": false,
+            "sqlalchemy_uri": "postgresql://metadata:XXXXXXXXXX@metadatadb:5432/metadata",
+            "force_ctas_schema": null,
+            "password": "metadata",
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        },
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 35,
+              "filterable": true,
+              "type": "INT",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:51:05"
+              },
+              "column_name": "id",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 125,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:51:05"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 35,
+              "filterable": true,
+              "type": "STRING",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:51:05"
+              },
+              "column_name": "repository",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 126,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:51:05"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 35,
+              "filterable": true,
+              "type": "DATETIME",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:51:05"
+              },
+              "column_name": "created_at",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 127,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:51:05"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 35,
+              "filterable": true,
+              "type": "DATETIME",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:51:05"
+              },
+              "column_name": "merged_at",
+              "python_date_format": null,
+              "is_dttm": true,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 128,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:51:05"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 35,
+              "filterable": true,
+              "type": "FLOAT",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:51:05"
+              },
+              "column_name": "days",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 129,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:51:05"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:51:05"
+              },
+              "id": 36,
+              "created_by_fk": 1,
+              "table_id": 35,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:51:05"
+              },
+              "changed_by_fk": 1
+            }
+          }
+        ]
+      }
+    },
+    {
+      "__SqlaTable__": {
+        "database_id": 2,
+        "is_featured": false,
+        "fetch_values_predicate": null,
+        "filter_select_enabled": false,
+        "schema": "public",
+        "offset": 0,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:23:59"
+        },
+        "sql": "SELECT CONCAT(repository_owner, '/', repository_name) AS repository, COUNT(merged_at) AS merged, (COUNT(closed_at) - COUNT(merged_at)) AS closed\nFROM pull_requests\nWHERE state <> 'open'\nGROUP BY repository",
+        "cache_timeout": null,
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:23:59"
+        },
+        "is_sqllab_view": true,
+        "params": "{\"remote_id\": 31, \"database_name\": \"metadata\"}",
+        "id": 31,
+        "template_params": "{}",
+        "perm": "[None].[pr_status-8jUyYteDu](id:31)",
+        "description": null,
+        "created_by_fk": 1,
+        "table_name": "pr_status-8jUyYteDu",
+        "default_endpoint": null,
+        "changed_by_fk": 1,
+        "main_dttm_col": null,
+        "database": {
+          "__Database__": {
+            "expose_in_sqllab": true,
+            "changed_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "perm": "[metadata].(id:2)",
+            "allow_run_async": false,
+            "id": 2,
+            "impersonate_user": false,
+            "allow_csv_upload": false,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_ctas": false,
+            "database_name": "metadata",
+            "changed_by_fk": null,
+            "allow_dml": false,
+            "sqlalchemy_uri": "postgresql://metadata:XXXXXXXXXX@metadatadb:5432/metadata",
+            "force_ctas_schema": null,
+            "password": "metadata",
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-06-18T15:21:11"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false
+          }
+        },
+        "columns": [
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 31,
+              "filterable": true,
+              "type": "STRING",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:23:59"
+              },
+              "column_name": "repository",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 113,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:23:59"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 31,
+              "filterable": true,
+              "type": "INT",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:23:59"
+              },
+              "column_name": "merged",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 114,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:23:59"
+              }
+            }
+          },
+          {
+            "__TableColumn__": {
+              "expression": "",
+              "table_id": 31,
+              "filterable": true,
+              "type": "INT",
+              "verbose_name": null,
+              "database_expression": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:23:59"
+              },
+              "column_name": "closed",
+              "python_date_format": null,
+              "is_dttm": false,
+              "description": null,
+              "groupby": true,
+              "is_active": true,
+              "created_by_fk": 1,
+              "id": 115,
+              "changed_by_fk": 1,
+              "created_on": {
+                "__datetime__": "2019-06-18T15:23:59"
+              }
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "expression": "count(*)",
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": null,
+              "metric_name": "count",
+              "created_on": {
+                "__datetime__": "2019-06-18T15:23:59"
+              },
+              "id": 32,
+              "created_by_fk": 1,
+              "table_id": 31,
+              "d3format": null,
+              "description": null,
+              "verbose_name": null,
+              "changed_on": {
+                "__datetime__": "2019-06-18T15:23:59"
+              },
+              "changed_by_fk": 1
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/srcd/dashboards/metadata/placeholder.json
+++ b/srcd/dashboards/metadata/placeholder.json
@@ -1,135 +1,25 @@
 {
-    "dashboards": [
-        {
-            "__Dashboard__": {
-                "position_json": "{\"DASHBOARD_VERSION_KEY\":\"v2\",\"GRID_ID\":{\"children\":[\"ROW-xWkd3z2SiP\"],\"id\":\"GRID_ID\",\"parents\":[\"ROOT_ID\"],\"type\":\"GRID\"},\"HEADER_ID\":{\"id\":\"HEADER_ID\",\"meta\":{\"text\":\"Welcome\"},\"type\":\"HEADER\"},\"MARKDOWN-MIE5EqOv00\":{\"children\":[],\"id\":\"MARKDOWN-MIE5EqOv00\",\"meta\":{\"code\":\"# \\u2728Placeholder\\n\\nDescription how everything works and a progress bar.\",\"height\":48,\"width\":12},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-xWkd3z2SiP\"],\"type\":\"MARKDOWN\"},\"ROOT_ID\":{\"children\":[\"GRID_ID\"],\"id\":\"ROOT_ID\",\"type\":\"ROOT\"},\"ROW-xWkd3z2SiP\":{\"children\":[\"MARKDOWN-MIE5EqOv00\"],\"id\":\"ROW-xWkd3z2SiP\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"}}",
-                "id": 2,
-                "created_on": {
-                    "__datetime__": "2019-06-14T14:07:34"
-                },
-                "created_by_fk": 1,
-                "json_metadata": "{\"filter_immune_slices\": [], \"timed_refresh_immune_slices\": [], \"filter_immune_slice_fields\": {}, \"expanded_slices\": {}, \"refresh_frequency\": 0, \"default_filters\": \"{}\", \"remote_id\": 2}",
-                "description": null,
-                "dashboard_title": "Welcome",
-                "changed_on": {
-                    "__datetime__": "2019-06-14T14:08:35"
-                },
-                "changed_by_fk": 1,
-                "slug": null,
-                "css": "",
-                "slices": []
-            }
-        }
-    ],
-    "datasources": [
-        {
-            "__SqlaTable__": {
-                "database_id": 1,
-                "is_featured": false,
-                "fetch_values_predicate": null,
-                "filter_select_enabled": false,
-                "schema": null,
-                "offset": 0,
-                "created_on": {
-                    "__datetime__": "2019-06-14T14:06:04"
-                },
-                "sql": "select * from repositories",
-                "cache_timeout": null,
-                "changed_on": {
-                    "__datetime__": "2019-06-14T14:06:33"
-                },
-                "is_sqllab_view": false,
-                "params": "{\"remote_id\": 10, \"database_name\": \"gitbase\", \"import_time\": 1560521193}",
-                "id": 10,
-                "template_params": null,
-                "perm": "[gitbase].[gitbase.repositories](id:10)",
-                "description": null,
-                "created_by_fk": null,
-                "table_name": "gitbase.repositories",
-                "default_endpoint": null,
-                "changed_by_fk": null,
-                "main_dttm_col": null,
-                "columns": [
-                    {
-                        "__TableColumn__": {
-                            "expression": "",
-                            "table_id": 10,
-                            "filterable": false,
-                            "type": "TEXT",
-                            "verbose_name": null,
-                            "database_expression": null,
-                            "column_name": "repository_id",
-                            "changed_on": {
-                                "__datetime__": "2019-06-14T14:06:28"
-                            },
-                            "created_by_fk": null,
-                            "python_date_format": null,
-                            "is_dttm": false,
-                            "description": null,
-                            "groupby": false,
-                            "is_active": true,
-                            "id": 47,
-                            "changed_by_fk": null,
-                            "created_on": {
-                                "__datetime__": "2019-06-14T14:06:04"
-                            }
-                        }
-                    }
-                ],
-                "metrics": [
-                    {
-                        "__SqlMetric__": {
-                            "expression": "COUNT(*)",
-                            "warning_text": null,
-                            "is_restricted": false,
-                            "metric_type": "count",
-                            "metric_name": "count",
-                            "created_on": {
-                                "__datetime__": "2019-06-14T14:06:04"
-                            },
-                            "id": 10,
-                            "created_by_fk": null,
-                            "table_id": 10,
-                            "d3format": null,
-                            "description": null,
-                            "verbose_name": "COUNT(*)",
-                            "changed_on": {
-                                "__datetime__": "2019-06-14T14:06:04"
-                            },
-                            "changed_by_fk": null
-                        }
-                    }
-                ],
-                "database": {
-                    "__Database__": {
-                        "expose_in_sqllab": true,
-                        "changed_on": {
-                            "__datetime__": "2019-06-14T14:06:02"
-                        },
-                        "perm": "[gitbase].(id:1)",
-                        "allow_run_async": true,
-                        "id": 1,
-                        "impersonate_user": false,
-                        "allow_csv_upload": false,
-                        "verbose_name": null,
-                        "created_by_fk": null,
-                        "allow_ctas": false,
-                        "database_name": "gitbase",
-                        "changed_by_fk": null,
-                        "allow_dml": true,
-                        "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
-                        "force_ctas_schema": null,
-                        "password": null,
-                        "allow_multi_schema_metadata_fetch": false,
-                        "cache_timeout": null,
-                        "created_on": {
-                            "__datetime__": "2019-06-14T14:06:02"
-                        },
-                        "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
-                        "select_as_create_table_as": false
-                    }
-                }
-            }
-        }
-    ]
+  "dashboards": [
+    {
+      "__Dashboard__": {
+        "position_json": "{\"DASHBOARD_VERSION_KEY\": \"v2\", \"GRID_ID\": {\"children\": [\"ROW-xWkd3z2SiP\"], \"id\": \"GRID_ID\", \"parents\": [\"ROOT_ID\"], \"type\": \"GRID\"}, \"HEADER_ID\": {\"id\": \"HEADER_ID\", \"meta\": {\"text\": \"Welcome\"}, \"type\": \"HEADER\"}, \"MARKDOWN-MIE5EqOv00\": {\"children\": [], \"id\": \"MARKDOWN-MIE5EqOv00\", \"meta\": {\"code\": \"# \\u2728Placeholder\\n\\nDescription how everything works and a progress bar.\", \"height\": 48, \"width\": 12}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-xWkd3z2SiP\"], \"type\": \"MARKDOWN\"}, \"ROOT_ID\": {\"children\": [\"GRID_ID\"], \"id\": \"ROOT_ID\", \"type\": \"ROOT\"}, \"ROW-xWkd3z2SiP\": {\"children\": [\"MARKDOWN-MIE5EqOv00\"], \"id\": \"ROW-xWkd3z2SiP\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}}",
+        "id": 2,
+        "created_on": {
+          "__datetime__": "2019-06-18T15:22:06"
+        },
+        "created_by_fk": null,
+        "json_metadata": "{\"filter_immune_slices\": [], \"timed_refresh_immune_slices\": [], \"filter_immune_slice_fields\": {}, \"expanded_slices\": {}, \"refresh_frequency\": 0, \"default_filters\": \"{}\", \"remote_id\": 2, \"import_time\": 1560871326}",
+        "description": null,
+        "dashboard_title": "Welcome",
+        "changed_on": {
+          "__datetime__": "2019-06-18T15:22:06"
+        },
+        "changed_by_fk": null,
+        "slug": null,
+        "css": "",
+        "slices": []
+      }
+    }
+  ],
+  "datasources": []
 }


### PR DESCRIPTION
Only charts based on fast data.
PR changes other dashboards too to make the ids correct.

Fix: #111

![Screenshot_2019-06-18 Collaboration(2)](https://user-images.githubusercontent.com/406916/59701656-5f65cc00-91f6-11e9-8b29-45468bc6ced1.png)

any improvements to the charts and layouts will be done by product team.