### PR TITLE
This replaces UAST Lab from steam icon to tree icon

### DIFF
--- a/srcd/superset/bblfsh/views.py
+++ b/srcd/superset/bblfsh/views.py
@@ -50,4 +50,4 @@ class Bblfsh(BaseSupersetView):
 
 
 appbuilder.add_view(Bblfsh, 'UAST', label=_('UAST'),
-                    category_icon='fa-steam', icon='fa-steam')
+                    category_icon='fa-tree', icon='fa-tree')


### PR DESCRIPTION
This commit replaces UAST Lab fontawesome steam icon for tree icon.

Signed-off-by: Ricardo Baeta <ricardo@ricardobaeta.com>

Before:
![image](https://user-images.githubusercontent.com/1746146/59955175-ae269680-9480-11e9-91a6-8bd292fa3587.png)

After:
![image](https://user-images.githubusercontent.com/1746146/59955220-e3cb7f80-9480-11e9-974f-678423b2b069.png)

Alternative: We're able to add a class to the UAST tab `<li>` and I can apply any .svg that we want.