### PR TITLE
Import dashboards in a fixed order

### DIFF
--- a/superset/contrib/docker/docker-init.sh
+++ b/superset/contrib/docker/docker-init.sh
@@ -43,11 +43,16 @@ if ! fabmanager list-users --app superset | grep -q $ADMIN_LOGIN; then
     superset init
 
     # Add dashboards
-    superset import_dashboards --recursive --path /home/superset/dashboards/gitbase
+    superset import_dashboards --path /home/superset/dashboards/gitbase/welcome.json
 
     # Add metadata dashboards and set welcome dashboard as a default
     if [ ! -z "$SYNC_MODE" ]; then
-        superset import_dashboards --recursive --path /home/superset/dashboards/metadata
+        sleep 2s
+        superset import_dashboards --path /home/superset/dashboards/metadata/placeholder.json
+
+        sleep 2s
+        superset import_dashboards --path /home/superset/dashboards/metadata/collaboration.json
+
         python set_default_dashboard.py
     fi
 fi


### PR DESCRIPTION
Fix #156.

This imports the dashboards in the order defined by their IDs.
I added `sleep` because of this comment https://github.com/src-d/sourced-ui/issues/156#issuecomment-504945680. Overview was always added before any of the other 2, it does not make sense that it gets ID 3, so I thought maybe there is something running in parallel that could be causing that...