### PR TITLE
Fix hidden x-scrollbar

### DIFF
--- a/srcd/superset/assets/stylesheets/less/custom-brand.less
+++ b/srcd/superset/assets/stylesheets/less/custom-brand.less
@@ -809,14 +809,20 @@ h4.panel-title {
 
 //= Layout Adjustments
 
-.SqlEditor .SouthPane {
-  margin-top: 20px;
-
-  .tab-content {
-    margin-top: 12px;
+.SqlEditor .queryPane {
+  .gutter {
+    margin: 15px auto 7px;
   }
 
-  .ResultSetControls {
-    margin-bottom: 12px;
+  .SouthPane {
+    padding-bottom: 20px;
+
+    .tab-content {
+      margin-top: 12px;
+    }
+
+    .ResultSetControls {
+      margin-bottom: 12px;
+    }
   }
 }


### PR DESCRIPTION
fix #184

I fixed the position of the resizer "slider" in the middle.
And added some margin in the bottom of the results place to reveal the horizontal scroll bar.

If approved, sql panel would look like as :point_down: 

![image](https://user-images.githubusercontent.com/2437584/61050421-401e2100-a3e7-11e9-8f5f-7219b7481a92.png)
