### PR TITLE
Fix hidden x-scrollbar

### DIFF
--- a/srcd/superset/assets/stylesheets/less/custom-brand.less
+++ b/srcd/superset/assets/stylesheets/less/custom-brand.less
@@ -809,14 +809,34 @@ h4.panel-title {
 
 //= Layout Adjustments
 
-.SqlEditor .SouthPane {
-  margin-top: 20px;
-
-  .tab-content {
-    margin-top: 12px;
+.SqlEditor {
+  .gutter {
+    margin: 15px auto 7px !important;
   }
 
-  .ResultSetControls {
-    margin-bottom: 12px;
+  .SouthPane {
+    padding-bottom: 15px;
+
+    .tab-content > .tab-pane {
+      padding-top: 12px;
+    }
+
+    .filterable-table-container {
+      height: auto !important;
+      position: absolute;
+      top: 76px;
+      bottom: 0px;
+      left: 0;
+      right: 0;
+      overflow: auto hidden;
+
+      .ReactVirtualized__Table__Grid{
+        height: auto !important;
+        position: absolute !important;
+        top: 32px;
+        bottom: 0;
+        left: 0;
+      }
+    }
   }
 }


### PR DESCRIPTION
fix #184
supersedes #209
related to https://github.com/src-d/sourced-ui/pull/196#issuecomment-508538202


Superset calculates the height of the filtered table with javascript, using hardcoded heights for tabs [[1]](https://github.com/src-d/sourced-ui/blob/master/superset/superset/assets/src/SqlLab/components/SouthPane.jsx#L32) and buttons [[2]](https://github.com/src-d/sourced-ui/blob/master/superset/superset/assets/src/SqlLab/components/ResultSet.jsx#L54), so when there is more than one line of tabs, the filtered table does not fit in the available space, appearing a new outer scroll (as it can be seen in the screenshot below) as described by #184.

With this PR, the filtered table is positioned using absolute coordinates, leaving space for all the components in the panel, no matter how much lines of tabs are opened.

If this PR is approved, the SQL Lab would be like this :point_down:

![image](https://user-images.githubusercontent.com/2437584/61125963-7a50f680-a4ab-11e9-81b4-070c6faa8c18.png)

instead of how it was in the previous version without branding: `v0.3.0` :point_down:

![image](https://user-images.githubusercontent.com/2437584/61125806-17f7f600-a4ab-11e9-89d9-1b7a4102a860.png)
