### PR TITLE
Remove changed_on field from dashboard export

### DIFF
--- a/superset/superset/utils/core.py
+++ b/superset/superset/utils/core.py
@@ -281,7 +281,8 @@ class DashboardEncoder(json.JSONEncoder):
     def default(self, o):
         try:
             vals = {
-                k: v for k, v in o.__dict__.items() if k != '_sa_instance_state'}
+                k: v for k, v in o.__dict__.items()
+                if k not in ('_sa_instance_state', 'changed_on')}
             return {'__{}__'.format(o.__class__.__name__): vals}
         except Exception:
             if type(o) == datetime:


### PR DESCRIPTION
Fix: #214

Solved the simple possible way to avoid huge conflicts with next merge
of upstream. The proper solution would be to export only fields listed
in `export_fields`. This work is on-going in upstream.

Signed-off-by: Maxim Sukharev <max@smacker.ru>