### PR TITLE
Disable druid

### DIFF
--- a/superset/contrib/docker/superset_config.py
+++ b/superset/contrib/docker/superset_config.py
@@ -1,6 +1,16 @@
+from collections import OrderedDict
 import os
 
 from werkzeug.contrib.cache import RedisCache
+
+
+# Disable druid
+
+DRUID_IS_ACTIVE = False
+
+DEFAULT_MODULE_DS_MAP = OrderedDict([
+    ('superset.connectors.sqla.models', ['SqlaTable']),
+])
 
 
 # Helper functions


### PR DESCRIPTION
Source{d} doesn't support druid clusters as datasources.

Before:
<img width="279" alt="Screenshot 2019-08-05 at 12 46 45" src="https://user-images.githubusercontent.com/406916/62459237-2ae6a900-b77f-11e9-9b04-573a7ccffa0f.png">

After:
<img width="224" alt="Screenshot 2019-08-05 at 12 46 55" src="https://user-images.githubusercontent.com/406916/62459245-2f12c680-b77f-11e9-9827-7fc79e75412f.png">

