### PR TITLE
Add sparksql engine spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 ## [Unreleased]
 <details>
   <summary>
-    Changes that have landed in master but are not yet released.
-    Click to see more.
+
+### Fixed
+
+- Timestamp type not mapped correctly from Spark SQL to Hive ([#227](https://github.com/src-d/sourced-ui/issues/227))
+
   </summary>
 
 </details>

--- a/superset/contrib/docker/superset_config.py
+++ b/superset/contrib/docker/superset_config.py
@@ -96,11 +96,16 @@ if GITBASE_USER:
     if GITBASE_PASSWORD:
         GITBASE_AUTH += ':%s' % GITBASE_PASSWORD
     GITBASE_AUTH += '@'
-GITBASE_DATABASE_URI = '%s://%s%s:%s/%s?charset=utf8' % (GITBASE_PREFIX,
-                                                         GITBASE_AUTH,
-                                                         GITBASE_HOST,
-                                                         GITBASE_PORT,
-                                                         GITBASE_DB)
+
+GITBASE_QUERY_PARAMS = ''
+if not IS_EE:
+    GITBASE_QUERY_PARAMS = '?charset=utf8'
+GITBASE_DATABASE_URI = '%s://%s%s:%s/%s%s' % (GITBASE_PREFIX,
+                                              GITBASE_AUTH,
+                                              GITBASE_HOST,
+                                              GITBASE_PORT,
+                                              GITBASE_DB,
+                                              GITBASE_QUERY_PARAMS)
 
 SQLLAB_DEFAULT_DBID = 2  # set gitbase as default DB in SQL Lab
 

--- a/superset/superset/db_engine_specs.py
+++ b/superset/superset/db_engine_specs.py
@@ -1411,6 +1411,16 @@ class HiveEngineSpec(PrestoEngineSpec):
         cursor.execute(query, **kwargs)
 
 
+class SparkSQLEngineSpec(HiveEngineSpec):
+    """Reuses HiveEngineSpec functionality."""
+
+    engine = 'sparksql'
+
+    @classmethod
+    def get_view_names(cls, inspector, schema):
+        return BaseEngineSpec.get_view_names(inspector, schema)
+
+
 class MssqlEngineSpec(BaseEngineSpec):
     engine = 'mssql'
     epoch_to_dttm = "dateadd(S, {col}, '1970-01-01')"


### PR DESCRIPTION
Closes #227.

By connecting to `gsc` through `sparksql://gsc:10000/default`, sourced-ui is currently using `BaseEngineSpec` because that engine is the fallback for databases whose backend doesn't have a corresponding engine spec. In this case the backend for the `gitbase` Database is `sparksql` that doesn't have a corresponding engine spec. All the engines specs are registered [here](https://github.com/src-d/sourced-ui/blob/master/superset/superset/db_engine_specs.py#L1810).

This PR adds a `SparkSQLEngineSpec` that inherits from `HiveEngineSpec` and sets the correct engine name.

Using the `SparkSQLEngineSpec` fixes the bug #227, but broke the listing of the available views in the SQL Editor tab. These views are listed by calling the `get_views_name` name of the corresponding engine spec, but in this case, it's shadowed by the inherited classes (more details [here](https://github.com/apache/incubator-superset/issues/8010)). This has been fixed by redefining the `get_views_name` class method in `HiveEngineSpec`.

Additionally, the SparkSQL dialect doesn't support passing charset (nor presto, nor hive), but it shouldn't be required as thrift server uses `utf8` by default.