### PR TITLE
Fix SQL Lab tables' preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - Timestamp type not mapped correctly from Spark SQL to Hive ([#227](https://github.com/src-d/sourced-ui/issues/227))
+- Fix tables' preview in SQL Lab for SparkSQL engine ([#246](https://github.com/src-d/sourced-ui/pull/246))
 
   </summary>
 

--- a/superset/superset/db_engine_specs.py
+++ b/superset/superset/db_engine_specs.py
@@ -1420,6 +1420,17 @@ class SparkSQLEngineSpec(HiveEngineSpec):
     def get_view_names(cls, inspector, schema):
         return BaseEngineSpec.get_view_names(inspector, schema)
 
+    @classmethod
+    def select_star(cls, my_db, table_name, engine, schema=None, limit=100,
+                    show_cols=False, indent=True, latest_partition=True,
+                    cols=None):
+        schema = None if schema == 'default' else schema
+        return super(SparkSQLEngineSpec, cls).select_star(
+            my_db, table_name, engine, schema=schema, limit=limit,
+            show_cols=show_cols, indent=indent, latest_partition=latest_partition,
+            cols=cols
+        )
+
 
 class MssqlEngineSpec(BaseEngineSpec):
     engine = 'mssql'


### PR DESCRIPTION
~Based on #244.~
Closes #245.

This fixes getting the table preview in SQL Lab for SparkSQL engine.