### PR TITLE
Fix sorting in most active repos chart

### DIFF
--- a/srcd/dashboards/metadata/collaboration.json
+++ b/srcd/dashboards/metadata/collaboration.json
@@ -6,25 +6,14 @@
                 "dashboard_title": "Collaboration",
                 "description": null,
                 "json_metadata": "{\"filter_immune_slices\": [], \"timed_refresh_immune_slices\": [], \"filter_immune_slice_fields\": {}, \"expanded_slices\": {}, \"refresh_frequency\": 0, \"default_filters\": \"{}\", \"remote_id\": \"89a7262e-fad6-4dd1-bc4e-9f583376e510\"}",
-                "position_json": "{\"CHART-3F9wGa1nVe\":{\"children\":[],\"id\":\"CHART-3F9wGa1nVe\",\"meta\":{\"chartId\":25,\"height\":49,\"sliceName\":\"Most Active Repositories\",\"width\":12},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-Ixfutv2rRl\"],\"type\":\"CHART\"},\"CHART-5FbG_o7Awy\":{\"children\":[],\"id\":\"CHART-5FbG_o7Awy\",\"meta\":{\"chartId\":29,\"height\":50,\"sliceName\":\"Time to Merge Change Over Time\",\"width\":6},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-Re8r7jF5U\"],\"type\":\"CHART\"},\"CHART-CxhPIuq8WU\":{\"children\":[],\"id\":\"CHART-CxhPIuq8WU\",\"meta\":{\"chartId\":26,\"height\":50,\"sliceName\":\"Breakdown by Pull Request Outcome\",\"width\":6},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-Re8r7jF5U\"],\"type\":\"CHART\"},\"CHART-H_hOSBOPpo\":{\"children\":[],\"id\":\"CHART-H_hOSBOPpo\",\"meta\":{\"chartId\":30,\"height\":81,\"sliceName\":\"Pull Requests Workflow\",\"width\":12},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-vMR1OCiTh\"],\"type\":\"CHART\"},\"CHART-P3ebofatqz\":{\"children\":[],\"id\":\"CHART-P3ebofatqz\",\"meta\":{\"chartId\":24,\"height\":45,\"sliceName\":\"# of pull requests created\",\"width\":12},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-FTyrflnSnH\"],\"type\":\"CHART\"},\"CHART-VN6sVVMmGQ\":{\"children\":[],\"id\":\"CHART-VN6sVVMmGQ\",\"meta\":{\"chartId\":27,\"height\":50,\"sliceName\":\"Avg. Time to Merge\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-BFazKQCAx\"],\"type\":\"CHART\"},\"CHART-oaC094q3qs\":{\"children\":[],\"id\":\"CHART-oaC094q3qs\",\"meta\":{\"chartId\":23,\"height\":50,\"sliceName\":\"Not Merged Pull Requests\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-BFazKQCAx\"],\"type\":\"CHART\"},\"CHART-v08M9Dd851\":{\"children\":[],\"id\":\"CHART-v08M9Dd851\",\"meta\":{\"chartId\":28,\"height\":50,\"sliceName\":\"Median Time to Merge\",\"width\":4},\"parents\":[\"ROOT_ID\",\"GRID_ID\",\"ROW-BFazKQCAx\"],\"type\":\"CHART\"},\"DASHBOARD_VERSION_KEY\":\"v2\",\"GRID_ID\":{\"children\":[\"ROW-BFazKQCAx\",\"ROW-Ixfutv2rRl\",\"ROW-FTyrflnSnH\",\"ROW-Re8r7jF5U\",\"ROW-vMR1OCiTh\"],\"id\":\"GRID_ID\",\"parents\":[\"ROOT_ID\"],\"type\":\"GRID\"},\"HEADER_ID\":{\"id\":\"HEADER_ID\",\"meta\":{\"text\":\"Collaboration\"},\"type\":\"HEADER\"},\"ROOT_ID\":{\"children\":[\"GRID_ID\"],\"id\":\"ROOT_ID\",\"type\":\"ROOT\"},\"ROW-BFazKQCAx\":{\"children\":[\"CHART-oaC094q3qs\",\"CHART-VN6sVVMmGQ\",\"CHART-v08M9Dd851\"],\"id\":\"ROW-BFazKQCAx\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-FTyrflnSnH\":{\"children\":[\"CHART-P3ebofatqz\"],\"id\":\"ROW-FTyrflnSnH\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-Ixfutv2rRl\":{\"children\":[\"CHART-3F9wGa1nVe\"],\"id\":\"ROW-Ixfutv2rRl\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-Re8r7jF5U\":{\"children\":[\"CHART-5FbG_o7Awy\",\"CHART-CxhPIuq8WU\"],\"id\":\"ROW-Re8r7jF5U\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"},\"ROW-vMR1OCiTh\":{\"children\":[\"CHART-H_hOSBOPpo\"],\"id\":\"ROW-vMR1OCiTh\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"parents\":[\"ROOT_ID\",\"GRID_ID\"],\"type\":\"ROW\"}}",
+                "position_json": "{\"CHART-3F9wGa1nVe\": {\"children\": [], \"id\": \"CHART-3F9wGa1nVe\", \"meta\": {\"chartId\": 27, \"height\": 49, \"sliceName\": \"Most Active Repositories\", \"width\": 12}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-Ixfutv2rRl\"], \"type\": \"CHART\"}, \"CHART-5FbG_o7Awy\": {\"children\": [], \"id\": \"CHART-5FbG_o7Awy\", \"meta\": {\"chartId\": 30, \"height\": 50, \"sliceName\": \"Time to Merge Change Over Time\", \"width\": 6}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-Re8r7jF5U\"], \"type\": \"CHART\"}, \"CHART-CxhPIuq8WU\": {\"children\": [], \"id\": \"CHART-CxhPIuq8WU\", \"meta\": {\"chartId\": 25, \"height\": 50, \"sliceName\": \"Breakdown by Pull Request Outcome\", \"width\": 6}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-Re8r7jF5U\"], \"type\": \"CHART\"}, \"CHART-H_hOSBOPpo\": {\"children\": [], \"id\": \"CHART-H_hOSBOPpo\", \"meta\": {\"chartId\": 29, \"height\": 81, \"sliceName\": \"Pull Requests Workflow\", \"width\": 12}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-vMR1OCiTh\"], \"type\": \"CHART\"}, \"CHART-P3ebofatqz\": {\"children\": [], \"id\": \"CHART-P3ebofatqz\", \"meta\": {\"chartId\": 23, \"height\": 45, \"sliceName\": \"# of pull requests created\", \"width\": 12}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-FTyrflnSnH\"], \"type\": \"CHART\"}, \"CHART-VN6sVVMmGQ\": {\"children\": [], \"id\": \"CHART-VN6sVVMmGQ\", \"meta\": {\"chartId\": 24, \"height\": 50, \"sliceName\": \"Avg. Time to Merge\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-BFazKQCAx\"], \"type\": \"CHART\"}, \"CHART-oaC094q3qs\": {\"children\": [], \"id\": \"CHART-oaC094q3qs\", \"meta\": {\"chartId\": 28, \"height\": 50, \"sliceName\": \"Not Merged Pull Requests\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-BFazKQCAx\"], \"type\": \"CHART\"}, \"CHART-v08M9Dd851\": {\"children\": [], \"id\": \"CHART-v08M9Dd851\", \"meta\": {\"chartId\": 26, \"height\": 50, \"sliceName\": \"Median Time to Merge\", \"width\": 4}, \"parents\": [\"ROOT_ID\", \"GRID_ID\", \"ROW-BFazKQCAx\"], \"type\": \"CHART\"}, \"DASHBOARD_VERSION_KEY\": \"v2\", \"GRID_ID\": {\"children\": [\"ROW-BFazKQCAx\", \"ROW-Ixfutv2rRl\", \"ROW-FTyrflnSnH\", \"ROW-Re8r7jF5U\", \"ROW-vMR1OCiTh\"], \"id\": \"GRID_ID\", \"parents\": [\"ROOT_ID\"], \"type\": \"GRID\"}, \"HEADER_ID\": {\"id\": \"HEADER_ID\", \"meta\": {\"text\": \"Collaboration\"}, \"type\": \"HEADER\"}, \"ROOT_ID\": {\"children\": [\"GRID_ID\"], \"id\": \"ROOT_ID\", \"type\": \"ROOT\"}, \"ROW-BFazKQCAx\": {\"children\": [\"CHART-oaC094q3qs\", \"CHART-VN6sVVMmGQ\", \"CHART-v08M9Dd851\"], \"id\": \"ROW-BFazKQCAx\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}, \"ROW-FTyrflnSnH\": {\"children\": [\"CHART-P3ebofatqz\"], \"id\": \"ROW-FTyrflnSnH\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}, \"ROW-Ixfutv2rRl\": {\"children\": [\"CHART-3F9wGa1nVe\"], \"id\": \"ROW-Ixfutv2rRl\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}, \"ROW-Re8r7jF5U\": {\"children\": [\"CHART-5FbG_o7Awy\", \"CHART-CxhPIuq8WU\"], \"id\": \"ROW-Re8r7jF5U\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}, \"ROW-vMR1OCiTh\": {\"children\": [\"CHART-H_hOSBOPpo\"], \"id\": \"ROW-vMR1OCiTh\", \"meta\": {\"background\": \"BACKGROUND_TRANSPARENT\"}, \"parents\": [\"ROOT_ID\", \"GRID_ID\"], \"type\": \"ROW\"}}",
                 "slices": [
-                    {
-                        "__Slice__": {
-                            "cache_timeout": null,
-                            "datasource_name": "public.pr_status-8jUyYteDu",
-                            "datasource_type": "table",
-                            "id": 23,
-                            "params": "{\"adhoc_filters\": [], \"datasource\": \"31__table\", \"granularity_sqla\": null, \"metric\": {\"aggregate\": null, \"column\": null, \"expressionType\": \"SQL\", \"fromFormData\": true, \"hasCustomLabel\": false, \"label\": \"SUM(closed)*1.0/(SUM(merged)+SUM(closed))\", \"optionName\": \"metric_0q0ckjqq7qoa_9awq4k5lq6v\", \"sqlExpression\": \"SUM(closed)*1.0/(SUM(merged)+SUM(closed))\"}, \"slice_id\": 21, \"time_grain_sqla\": \"P1D\", \"time_range\": \"No filter\", \"viz_type\": \"big_number_total\", \"y_axis_format\": \",.1%\", \"remote_id\": \"391e939b-39dc-4bc0-b3dd-faa449191f91\", \"datasource_name\": \"public.pr_status-8jUyYteDu\", \"schema\": \"public.pr_status-8jUyYteDu\", \"database_name\": \"metadata\"}",
-                            "slice_name": "Not Merged Pull Requests",
-                            "viz_type": "big_number_total"
-                        }
-                    },
                     {
                         "__Slice__": {
                             "cache_timeout": null,
                             "datasource_name": "public.pr_created_at-RVVRcORPF",
                             "datasource_type": "table",
-                            "id": 24,
+                            "id": 23,
                             "params": "{\"adhoc_filters\": [], \"annotation_layers\": [], \"bottom_margin\": \"auto\", \"color_scheme\": \"SUPERSET_DEFAULT\", \"comparison_type\": \"values\", \"contribution\": false, \"datasource\": \"32__table\", \"granularity_sqla\": \"created_at\", \"groupby\": [], \"line_interpolation\": \"linear\", \"metrics\": [\"count\"], \"order_desc\": true, \"resample_fillmethod\": null, \"resample_how\": null, \"resample_rule\": null, \"rich_tooltip\": true, \"rolling_type\": \"None\", \"row_limit\": 1000, \"show_brush\": \"auto\", \"show_controls\": false, \"show_legend\": true, \"slice_id\": 22, \"stacked_style\": \"stack\", \"time_grain_sqla\": \"P1M\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"area\", \"x_axis_format\": \"%b/%y\", \"x_axis_label\": \"\", \"x_axis_showminmax\": false, \"x_ticks_layout\": \"auto\", \"y_axis_bounds\": [null, null], \"y_axis_format\": \".3s\", \"y_log_scale\": false, \"remote_id\": \"df9b4ac0-ac5c-4004-b85f-fddbfa0065f2\", \"datasource_name\": \"public.pr_created_at-RVVRcORPF\", \"schema\": \"public.pr_created_at-RVVRcORPF\", \"database_name\": \"metadata\"}",
                             "slice_name": "# of pull requests created",
                             "viz_type": "area"
@@ -35,21 +24,10 @@
                             "cache_timeout": null,
                             "datasource_name": "public.admin admin-pr_dates-4xBftRm5b",
                             "datasource_type": "table",
-                            "id": 25,
-                            "params": "{\"adhoc_filters\": [], \"bar_stacked\": true, \"bottom_margin\": \"auto\", \"color_scheme\": \"SUPERSET_DEFAULT\", \"columns\": [], \"contribution\": false, \"datasource\": \"33__table\", \"granularity_sqla\": \"created_at\", \"groupby\": [\"repository\"], \"metrics\": [{\"aggregate\": \"COUNT\", \"column\": {\"column_name\": \"merged_at\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 121, \"is_dttm\": true, \"optionName\": \"_col_merged_at\", \"python_date_format\": null, \"type\": \"DATETIME\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": true, \"hasCustomLabel\": true, \"label\": \"Merged\", \"optionName\": \"metric_jxumwoerhhf_6h4frowknyp\", \"sqlExpression\": null}, {\"aggregate\": null, \"column\": null, \"expressionType\": \"SQL\", \"fromFormData\": true, \"hasCustomLabel\": true, \"label\": \"Closed\", \"optionName\": \"metric_ub9fmazo6sg_kfzd36b2uv\", \"sqlExpression\": \"COUNT(closed_at)-COUNT(merged_at)\"}, {\"aggregate\": null, \"column\": null, \"expressionType\": \"SQL\", \"fromFormData\": true, \"hasCustomLabel\": true, \"label\": \"Open\", \"optionName\": \"metric_0bzo6iod7vl6_oxnj5hz10m\", \"sqlExpression\": \"COUNT(*)-COUNT(closed_at)\"}], \"order_bars\": false, \"reduce_x_ticks\": false, \"row_limit\": 1000, \"show_bar_value\": false, \"show_controls\": false, \"show_legend\": true, \"slice_id\": 23, \"time_grain_sqla\": \"P1D\", \"time_range\": \"Last 30 days\", \"viz_type\": \"dist_bar\", \"x_axis_label\": \"\", \"x_ticks_layout\": \"auto\", \"y_axis_format\": null, \"y_axis_label\": \"\", \"remote_id\": \"090f84ba-0c13-47d8-9661-75fc0b65dd5f\", \"datasource_name\": \"public.admin admin-pr_dates-4xBftRm5b\", \"schema\": \"public.admin admin-pr_dates-4xBftRm5b\", \"database_name\": \"metadata\"}",
-                            "slice_name": "Most Active Repositories",
+                            "id": 27,
+                            "params": "{\"adhoc_filters\": [], \"bar_stacked\": true, \"bottom_margin\": \"auto\", \"color_scheme\": \"SUPERSET_DEFAULT\", \"columns\": [\"mtype\"], \"contribution\": false, \"datasource\": \"35__table\", \"granularity_sqla\": \"created_at\", \"groupby\": [\"repository\"], \"metrics\": [{\"aggregate\": \"SUM\", \"column\": {\"column_name\": \"value\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 127, \"is_dttm\": false, \"optionName\": \"_col_value\", \"python_date_format\": null, \"type\": \"INT\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": false, \"hasCustomLabel\": false, \"label\": \"SUM(value)\", \"optionName\": \"metric_1x1g4rg96kl_nouczym0pmc\", \"sqlExpression\": null}], \"order_bars\": false, \"reduce_x_ticks\": false, \"row_limit\": 5000, \"show_bar_value\": false, \"show_controls\": false, \"show_legend\": true, \"slice_id\": 27, \"time_grain_sqla\": \"P1D\", \"time_range\": \"Last 30 days\", \"url_params\": {}, \"viz_type\": \"dist_bar\", \"x_axis_label\": \"\", \"x_ticks_layout\": \"auto\", \"y_axis_format\": null, \"y_axis_label\": \"\", \"remote_id\": \"090f84ba-0c13-47d8-9661-75fc0b65dd5f\", \"datasource_name\": \"public.admin admin-pr_dates-4xBftRm5b\", \"schema\": \"public.admin admin-pr_dates-4xBftRm5b\", \"database_name\": \"metadata\"}",
+                            "slice_name": "30 Most Active Repositories (Last 30 Days)",
                             "viz_type": "dist_bar"
-                        }
-                    },
-                    {
-                        "__Slice__": {
-                            "cache_timeout": null,
-                            "datasource_name": "public.pr_resolution-c5KRWDa_V",
-                            "datasource_type": "table",
-                            "id": 26,
-                            "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"34__table\", \"granularity_sqla\": null, \"groupby\": [\"repository\", \"resolution_type\"], \"metric\": \"count\", \"row_limit\": 1000, \"secondary_metric\": null, \"slice_id\": 24, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"sunburst\", \"remote_id\": \"009d992c-b750-4886-8193-ed2f5f0e68c8\", \"datasource_name\": \"public.pr_resolution-c5KRWDa_V\", \"schema\": \"public.pr_resolution-c5KRWDa_V\", \"database_name\": \"metadata\"}",
-                            "slice_name": "Breakdown by Pull Request Outcome",
-                            "viz_type": "sunburst"
                         }
                     },
                     {
@@ -57,7 +35,7 @@
                             "cache_timeout": null,
                             "datasource_name": "public.pr_time_to_merge-ejLXE2oaX",
                             "datasource_type": "table",
-                            "id": 27,
+                            "id": 24,
                             "params": "{\"adhoc_filters\": [], \"datasource\": \"35__table\", \"granularity_sqla\": \"created_at\", \"metric\": {\"aggregate\": \"AVG\", \"column\": {\"column_name\": \"days\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 129, \"is_dttm\": false, \"optionName\": \"_col_days\", \"python_date_format\": null, \"type\": \"FLOAT\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": false, \"hasCustomLabel\": false, \"label\": \"AVG(days)\", \"optionName\": \"metric_qd4g8quql4_o3a11vjb6ci\", \"sqlExpression\": null}, \"slice_id\": 25, \"subheader\": \"Average number of days before merge\", \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"big_number_total\", \"y_axis_format\": \".3s\", \"remote_id\": \"dbe9a2c3-541b-48f0-bfa0-ac0dfe1efdcc\", \"datasource_name\": \"public.pr_time_to_merge-ejLXE2oaX\", \"schema\": \"public.pr_time_to_merge-ejLXE2oaX\", \"database_name\": \"metadata\"}",
                             "slice_name": "Avg. Time to Merge",
                             "viz_type": "big_number_total"
@@ -66,9 +44,20 @@
                     {
                         "__Slice__": {
                             "cache_timeout": null,
+                            "datasource_name": "public.pr_resolution-c5KRWDa_V",
+                            "datasource_type": "table",
+                            "id": 25,
+                            "params": "{\"adhoc_filters\": [], \"color_scheme\": \"SUPERSET_DEFAULT\", \"datasource\": \"34__table\", \"granularity_sqla\": null, \"groupby\": [\"repository\", \"resolution_type\"], \"metric\": \"count\", \"row_limit\": 1000, \"secondary_metric\": null, \"slice_id\": 24, \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"sunburst\", \"remote_id\": \"009d992c-b750-4886-8193-ed2f5f0e68c8\", \"datasource_name\": \"public.pr_resolution-c5KRWDa_V\", \"schema\": \"public.pr_resolution-c5KRWDa_V\", \"database_name\": \"metadata\"}",
+                            "slice_name": "Breakdown by Pull Request Outcome",
+                            "viz_type": "sunburst"
+                        }
+                    },
+                    {
+                        "__Slice__": {
+                            "cache_timeout": null,
                             "datasource_name": "public.pr_time_to_merge_median-_4s5FrIrI",
                             "datasource_type": "table",
-                            "id": 28,
+                            "id": 26,
                             "params": "{\"adhoc_filters\": [], \"datasource\": \"36__table\", \"granularity_sqla\": \"created_at\", \"metric\": {\"aggregate\": null, \"column\": null, \"expressionType\": \"SQL\", \"fromFormData\": true, \"hasCustomLabel\": false, \"label\": \"percentile_disc(0.5) WITHIN GROUP (ORDER...\", \"optionName\": \"metric_gzz9981bhx4_681hslzi1z\", \"sqlExpression\": \"percentile_disc(0.5) WITHIN GROUP (ORDER BY extract(epoch from time_to_merge) / 3600.00)\"}, \"slice_id\": 26, \"subheader\": \"Median number of hours before merge\", \"time_grain_sqla\": \"P1D\", \"time_range\": \"100 years ago : \", \"viz_type\": \"big_number_total\", \"y_axis_format\": \".3s\", \"remote_id\": \"a5294cf9-8287-49e8-bb3a-26879b78a740\", \"datasource_name\": \"public.pr_time_to_merge_median-_4s5FrIrI\", \"schema\": \"public.pr_time_to_merge_median-_4s5FrIrI\", \"database_name\": \"metadata\"}",
                             "slice_name": "Median Time to Merge",
                             "viz_type": "big_number_total"
@@ -77,12 +66,12 @@
                     {
                         "__Slice__": {
                             "cache_timeout": null,
-                            "datasource_name": "public.admin admin-pr_by_days-XSb1QtdX4",
+                            "datasource_name": "public.pr_status-8jUyYteDu",
                             "datasource_type": "table",
-                            "id": 29,
-                            "params": "{\"adhoc_filters\": [], \"annotation_layers\": [], \"bottom_margin\": \"auto\", \"color_scheme\": \"SUPERSET_DEFAULT\", \"comparison_type\": \"values\", \"contribution\": false, \"datasource\": \"37__table\", \"granularity_sqla\": \"created_at\", \"groupby\": [], \"left_margin\": \"auto\", \"line_interpolation\": \"cardinal\", \"metrics\": [{\"aggregate\": \"AVG\", \"column\": {\"column_name\": \"days\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 138, \"is_dttm\": false, \"optionName\": \"_col_days\", \"python_date_format\": null, \"type\": \"FLOAT\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": true, \"hasCustomLabel\": true, \"label\": \"Average\", \"optionName\": \"metric_v6tqzr5nihp_l7qb802z3jo\", \"sqlExpression\": null}], \"order_desc\": true, \"resample_fillmethod\": null, \"resample_how\": null, \"resample_rule\": null, \"rich_tooltip\": true, \"rolling_type\": \"None\", \"row_limit\": 1000, \"send_time_range\": false, \"show_brush\": \"auto\", \"show_legend\": true, \"show_markers\": true, \"slice_id\": 27, \"time_grain_sqla\": \"P1M\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"line\", \"x_axis_format\": \"%b/%y\", \"x_axis_label\": \"\", \"x_axis_showminmax\": false, \"x_ticks_layout\": \"auto\", \"y_axis_bounds\": [null, null], \"y_axis_format\": \".3s\", \"y_axis_label\": \"avg. # of days\", \"y_axis_showminmax\": false, \"y_log_scale\": false, \"remote_id\": \"459f2caf-abe7-4efc-90c0-b89c1c0b2561\", \"datasource_name\": \"public.admin admin-pr_by_days-XSb1QtdX4\", \"schema\": \"public.admin admin-pr_by_days-XSb1QtdX4\", \"database_name\": \"metadata\"}",
-                            "slice_name": "Time to Merge Change Over Time",
-                            "viz_type": "line"
+                            "id": 28,
+                            "params": "{\"adhoc_filters\": [], \"datasource\": \"31__table\", \"granularity_sqla\": null, \"metric\": {\"aggregate\": null, \"column\": null, \"expressionType\": \"SQL\", \"fromFormData\": true, \"hasCustomLabel\": false, \"label\": \"SUM(closed)*1.0/(SUM(merged)+SUM(closed))\", \"optionName\": \"metric_0q0ckjqq7qoa_9awq4k5lq6v\", \"sqlExpression\": \"SUM(closed)*1.0/(SUM(merged)+SUM(closed))\"}, \"slice_id\": 21, \"time_grain_sqla\": \"P1D\", \"time_range\": \"No filter\", \"viz_type\": \"big_number_total\", \"y_axis_format\": \",.1%\", \"remote_id\": \"391e939b-39dc-4bc0-b3dd-faa449191f91\", \"datasource_name\": \"public.pr_status-8jUyYteDu\", \"schema\": \"public.pr_status-8jUyYteDu\", \"database_name\": \"metadata\"}",
+                            "slice_name": "Not Merged Pull Requests",
+                            "viz_type": "big_number_total"
                         }
                     },
                     {
@@ -90,10 +79,21 @@
                             "cache_timeout": null,
                             "datasource_name": "public.pr_workflow-6tUyZn8RC",
                             "datasource_type": "table",
-                            "id": 30,
+                            "id": 29,
                             "params": "{\"adhoc_filters\": [], \"all_columns\": [\"repository\", \"number\", \"label\", \"event\", \"time\"], \"all_columns_x\": \"event\", \"datasource\": \"38__table\", \"entity\": \"label\", \"granularity_sqla\": \"time\", \"min_leaf_node_event_count\": 1, \"order_by_entity\": true, \"row_limit\": 10000, \"slice_id\": 28, \"time_grain_sqla\": \"PT1S\", \"time_range\": \"Last 30 days\", \"viz_type\": \"event_flow\", \"remote_id\": \"b0810a78-4130-4bcb-b3f2-8d5fd9dfe7f6\", \"datasource_name\": \"public.pr_workflow-6tUyZn8RC\", \"schema\": \"public.pr_workflow-6tUyZn8RC\", \"database_name\": \"metadata\"}",
                             "slice_name": "Pull Requests Workflow",
                             "viz_type": "event_flow"
+                        }
+                    },
+                    {
+                        "__Slice__": {
+                            "cache_timeout": null,
+                            "datasource_name": "public.admin admin-pr_by_days-XSb1QtdX4",
+                            "datasource_type": "table",
+                            "id": 30,
+                            "params": "{\"adhoc_filters\": [], \"annotation_layers\": [], \"bottom_margin\": \"auto\", \"color_scheme\": \"SUPERSET_DEFAULT\", \"comparison_type\": \"values\", \"contribution\": false, \"datasource\": \"37__table\", \"granularity_sqla\": \"created_at\", \"groupby\": [], \"left_margin\": \"auto\", \"line_interpolation\": \"cardinal\", \"metrics\": [{\"aggregate\": \"AVG\", \"column\": {\"column_name\": \"days\", \"database_expression\": null, \"description\": null, \"expression\": \"\", \"filterable\": true, \"groupby\": true, \"id\": 138, \"is_dttm\": false, \"optionName\": \"_col_days\", \"python_date_format\": null, \"type\": \"FLOAT\", \"verbose_name\": null}, \"expressionType\": \"SIMPLE\", \"fromFormData\": true, \"hasCustomLabel\": true, \"label\": \"Average\", \"optionName\": \"metric_v6tqzr5nihp_l7qb802z3jo\", \"sqlExpression\": null}], \"order_desc\": true, \"resample_fillmethod\": null, \"resample_how\": null, \"resample_rule\": null, \"rich_tooltip\": true, \"rolling_type\": \"None\", \"row_limit\": 1000, \"send_time_range\": false, \"show_brush\": \"auto\", \"show_legend\": true, \"show_markers\": true, \"slice_id\": 27, \"time_grain_sqla\": \"P1M\", \"time_range\": \"100 years ago : \", \"timeseries_limit_metric\": null, \"viz_type\": \"line\", \"x_axis_format\": \"%b/%y\", \"x_axis_label\": \"\", \"x_axis_showminmax\": false, \"x_ticks_layout\": \"auto\", \"y_axis_bounds\": [null, null], \"y_axis_format\": \".3s\", \"y_axis_label\": \"avg. # of days\", \"y_axis_showminmax\": false, \"y_log_scale\": false, \"remote_id\": \"459f2caf-abe7-4efc-90c0-b89c1c0b2561\", \"datasource_name\": \"public.admin admin-pr_by_days-XSb1QtdX4\", \"schema\": \"public.admin admin-pr_by_days-XSb1QtdX4\", \"database_name\": \"metadata\"}",
+                            "slice_name": "Time to Merge Change Over Time",
+                            "viz_type": "line"
                         }
                     }
                 ],
@@ -109,326 +109,10 @@
                     {
                         "__TableColumn__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "repository",
+                            "column_name": "closed",
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 146,
-                            "is_active": true,
-                            "is_dttm": false,
-                            "python_date_format": null,
-                            "table_id": 39,
-                            "type": "STRING",
-                            "verbose_name": null
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "created_at",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 147,
-                            "is_active": true,
-                            "is_dttm": true,
-                            "python_date_format": null,
-                            "table_id": 39,
-                            "type": "DATETIME",
-                            "verbose_name": null
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "merged_at",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 148,
-                            "is_active": true,
-                            "is_dttm": true,
-                            "python_date_format": null,
-                            "table_id": 39,
-                            "type": "DATETIME",
-                            "verbose_name": null
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "closed_at",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 149,
-                            "is_active": true,
-                            "is_dttm": true,
-                            "python_date_format": null,
-                            "table_id": 39,
-                            "type": "DATETIME",
-                            "verbose_name": null
-                        }
-                    }
-                ],
-                "database_id": 2,
-                "default_endpoint": null,
-                "description": null,
-                "fetch_values_predicate": null,
-                "filter_select_enabled": false,
-                "is_sqllab_view": true,
-                "main_dttm_col": null,
-                "metrics": [
-                    {
-                        "__SqlMetric__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "d3format": null,
-                            "description": null,
-                            "expression": "count(*)",
-                            "id": 40,
-                            "is_restricted": false,
-                            "metric_name": "count",
-                            "metric_type": null,
-                            "table_id": 39,
-                            "verbose_name": null,
-                            "warning_text": null
-                        }
-                    }
-                ],
-                "offset": 0,
-                "params": "{\"remote_id\": 33, \"database_name\": \"metadata\"}",
-                "schema": "public",
-                "sql": "SELECT CONCAT(repository_owner, '/', repository_name) AS repository, created_at, merged_at, closed_at \nFROM pull_requests",
-                "table_name": "admin admin-pr_dates-4xBftRm5b",
-                "template_params": "{}"
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "cache_timeout": null,
-                "columns": [
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "repository",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 150,
-                            "is_active": true,
-                            "is_dttm": false,
-                            "python_date_format": null,
-                            "table_id": 40,
-                            "type": "STRING",
-                            "verbose_name": null
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "number",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 151,
-                            "is_active": true,
-                            "is_dttm": false,
-                            "python_date_format": null,
-                            "table_id": 40,
-                            "type": "INT",
-                            "verbose_name": null
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "label",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 152,
-                            "is_active": true,
-                            "is_dttm": false,
-                            "python_date_format": null,
-                            "table_id": 40,
-                            "type": "STRING",
-                            "verbose_name": null
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "event",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 153,
-                            "is_active": true,
-                            "is_dttm": false,
-                            "python_date_format": null,
-                            "table_id": 40,
-                            "type": "STRING",
-                            "verbose_name": null
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "time",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 154,
-                            "is_active": true,
-                            "is_dttm": true,
-                            "python_date_format": null,
-                            "table_id": 40,
-                            "type": "DATETIME",
-                            "verbose_name": null
-                        }
-                    }
-                ],
-                "database_id": 2,
-                "default_endpoint": null,
-                "description": null,
-                "fetch_values_predicate": null,
-                "filter_select_enabled": false,
-                "is_sqllab_view": true,
-                "main_dttm_col": null,
-                "metrics": [
-                    {
-                        "__SqlMetric__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "d3format": null,
-                            "description": null,
-                            "expression": "count(*)",
-                            "id": 41,
-                            "is_restricted": false,
-                            "metric_name": "count",
-                            "metric_type": null,
-                            "table_id": 40,
-                            "verbose_name": null,
-                            "warning_text": null
-                        }
-                    }
-                ],
-                "offset": 0,
-                "params": "{\"remote_id\": 38, \"database_name\": \"metadata\"}",
-                "schema": "public",
-                "sql": "SELECT\n    repository,\n    number,\n    CONCAT(repository, '/pull/', number) AS label,\n    event,\n    time\n    FROM (\n        SELECT\n        CONCAT(repository_owner, '/', repository_name) AS repository,\n        number,\n        created_at AS created_datetime,\n        merged_at AS merged_datetime,\n        CASE\n            WHEN merged_at IS NOT NULL THEN NULL\n            ELSE closed_at\n        END AS closed_datetime,\n        closed_at,\n        merged_at\n        FROM pull_requests) t\n    JOIN LATERAL (\n        VALUES('created', t.created_datetime), ('closed', t.closed_datetime), ('merged', t.merged_datetime)) s(event, time) ON TRUE",
-                "table_name": "pr_workflow-6tUyZn8RC",
-                "template_params": "{}"
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "cache_timeout": null,
-                "columns": [
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "id",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:30"
                             },
                             "database_expression": null,
                             "description": null,
@@ -447,13 +131,10 @@
                     {
                         "__TableColumn__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "repository",
+                            "column_name": "merged",
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:30"
                             },
                             "database_expression": null,
                             "description": null,
@@ -465,20 +146,17 @@
                             "is_dttm": false,
                             "python_date_format": null,
                             "table_id": 33,
-                            "type": "STRING",
+                            "type": "INT",
                             "verbose_name": null
                         }
                     },
                     {
                         "__TableColumn__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "created_at",
+                            "column_name": "repository",
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:30"
                             },
                             "database_expression": null,
                             "description": null,
@@ -487,60 +165,10 @@
                             "groupby": true,
                             "id": 126,
                             "is_active": true,
-                            "is_dttm": true,
+                            "is_dttm": false,
                             "python_date_format": null,
                             "table_id": 33,
-                            "type": "DATETIME",
-                            "verbose_name": null
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "merged_at",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 127,
-                            "is_active": true,
-                            "is_dttm": true,
-                            "python_date_format": null,
-                            "table_id": 33,
-                            "type": "DATETIME",
-                            "verbose_name": null
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "time_to_merge",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 128,
-                            "is_active": true,
-                            "is_dttm": true,
-                            "python_date_format": null,
-                            "table_id": 33,
-                            "type": null,
+                            "type": "STRING",
                             "verbose_name": null
                         }
                     }
@@ -556,12 +184,9 @@
                     {
                         "__SqlMetric__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:30"
                             },
                             "d3format": null,
                             "description": null,
@@ -577,10 +202,10 @@
                     }
                 ],
                 "offset": 0,
-                "params": "{\"remote_id\": 36, \"database_name\": \"metadata\"}",
+                "params": "{\"remote_id\": 31, \"database_name\": \"metadata\"}",
                 "schema": "public",
-                "sql": "SELECT id, CONCAT(repository_owner, '/', repository_name) AS repository, created_at, merged_at, merged_at - created_at as time_to_merge\r\nFROM pull_requests \r\nWHERE merged_at IS NOT NULL",
-                "table_name": "pr_time_to_merge_median-_4s5FrIrI",
+                "sql": "SELECT CONCAT(repository_owner, '/', repository_name) AS repository, COUNT(merged_at) AS merged, (COUNT(closed_at) - COUNT(merged_at)) AS closed\nFROM pull_requests\nWHERE state <> 'open'\nGROUP BY repository",
+                "table_name": "pr_status-8jUyYteDu",
                 "template_params": "{}"
             }
         },
@@ -591,13 +216,10 @@
                     {
                         "__TableColumn__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "id",
+                            "column_name": "created_at",
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:31"
                             },
                             "database_expression": null,
                             "description": null,
@@ -606,23 +228,20 @@
                             "groupby": true,
                             "id": 131,
                             "is_active": true,
-                            "is_dttm": false,
+                            "is_dttm": true,
                             "python_date_format": null,
                             "table_id": 35,
-                            "type": "INT",
+                            "type": "DATETIME",
                             "verbose_name": null
                         }
                     },
                     {
                         "__TableColumn__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "repository",
+                            "column_name": "mtype",
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:31"
                             },
                             "database_expression": null,
                             "description": null,
@@ -641,13 +260,10 @@
                     {
                         "__TableColumn__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "created_at",
+                            "column_name": "repository",
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:31"
                             },
                             "database_expression": null,
                             "description": null,
@@ -656,23 +272,20 @@
                             "groupby": true,
                             "id": 133,
                             "is_active": true,
-                            "is_dttm": true,
+                            "is_dttm": false,
                             "python_date_format": null,
                             "table_id": 35,
-                            "type": "DATETIME",
+                            "type": "STRING",
                             "verbose_name": null
                         }
                     },
                     {
                         "__TableColumn__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "merged_at",
+                            "column_name": "value",
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:31"
                             },
                             "database_expression": null,
                             "description": null,
@@ -681,35 +294,10 @@
                             "groupby": true,
                             "id": 134,
                             "is_active": true,
-                            "is_dttm": true,
-                            "python_date_format": null,
-                            "table_id": 35,
-                            "type": "DATETIME",
-                            "verbose_name": null
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "days",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 135,
-                            "is_active": true,
                             "is_dttm": false,
                             "python_date_format": null,
                             "table_id": 35,
-                            "type": "FLOAT",
+                            "type": "INT",
                             "verbose_name": null
                         }
                     }
@@ -719,18 +307,15 @@
                 "description": null,
                 "fetch_values_predicate": null,
                 "filter_select_enabled": false,
-                "is_sqllab_view": true,
+                "is_sqllab_view": false,
                 "main_dttm_col": null,
                 "metrics": [
                     {
                         "__SqlMetric__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:31"
                             },
                             "d3format": null,
                             "description": null,
@@ -746,10 +331,10 @@
                     }
                 ],
                 "offset": 0,
-                "params": "{\"remote_id\": 35, \"database_name\": \"metadata\"}",
+                "params": "{\"remote_id\": 33, \"database_name\": \"metadata\"}",
                 "schema": "public",
-                "sql": "SELECT\r\n    id,\r\n    CONCAT(repository_owner, '/', repository_name) AS repository,\r\n    created_at,\r\n    merged_at, \r\n    extract(epoch from (merged_at - created_at)) / (3600.00 *24) as days\r\nFROM pull_requests \r\nWHERE merged_at IS NOT NULL",
-                "table_name": "pr_time_to_merge-ejLXE2oaX",
+                "sql": "SELECT * FROM (\n    SELECT\n        CONCAT(repository_owner, '/', repository_name) AS repository,\n        'merged' AS mtype,\n        1 AS value,\n        created_at\n    FROM pull_requests\n    WHERE merged_at IS NOT NULL\n    UNION\n    SELECT\n        CONCAT(repository_owner, '/', repository_name) AS repository,\n        'closed' AS mtype,\n        1 AS value,\n        created_at\n    FROM pull_requests\n    WHERE closed_at IS NOT NULL AND merged_at IS NULL\n    UNION\n    SELECT\n        CONCAT(repository_owner, '/', repository_name) AS repository,\n        'opened' AS mtype,\n        1 AS value,\n        created_at\n    FROM pull_requests\n    WHERE closed_at IS NULL\n) q1 WHERE repository IN (\n    SELECT\n        CONCAT(repository_owner, '/', repository_name) AS repository\n    FROM pull_requests\n    WHERE created_at >= '{{ from_dttm }}'\n    AND created_at <= '{{ to_dttm }}'\n    GROUP BY repository\n    ORDER BY COUNT(*) DESC\n    LIMIT 30\n)",
+                "table_name": "admin admin-pr_dates-4xBftRm5b",
                 "template_params": "{}"
             }
         },
@@ -760,49 +345,21 @@
                     {
                         "__TableColumn__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "id",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 143,
-                            "is_active": true,
-                            "is_dttm": false,
-                            "python_date_format": null,
-                            "table_id": 38,
-                            "type": "INT",
-                            "verbose_name": null
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
                             "column_name": "created_at",
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:31"
                             },
                             "database_expression": null,
                             "description": null,
                             "expression": "",
                             "filterable": true,
                             "groupby": true,
-                            "id": 144,
+                            "id": 152,
                             "is_active": true,
                             "is_dttm": true,
                             "python_date_format": null,
-                            "table_id": 38,
+                            "table_id": 40,
                             "type": "DATETIME",
                             "verbose_name": null
                         }
@@ -810,24 +367,43 @@
                     {
                         "__TableColumn__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "to_char",
+                            "column_name": "id",
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:31"
                             },
                             "database_expression": null,
                             "description": null,
                             "expression": "",
                             "filterable": true,
                             "groupby": true,
-                            "id": 145,
+                            "id": 153,
+                            "is_active": true,
+                            "is_dttm": false,
+                            "python_date_format": null,
+                            "table_id": 40,
+                            "type": "INT",
+                            "verbose_name": null
+                        }
+                    },
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "to_char",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 154,
                             "is_active": true,
                             "is_dttm": true,
                             "python_date_format": null,
-                            "table_id": 38,
+                            "table_id": 40,
                             "type": "STRING",
                             "verbose_name": null
                         }
@@ -844,21 +420,18 @@
                     {
                         "__SqlMetric__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:31"
                             },
                             "d3format": null,
                             "description": null,
                             "expression": "count(*)",
-                            "id": 39,
+                            "id": 41,
                             "is_restricted": false,
                             "metric_name": "count",
                             "metric_type": null,
-                            "table_id": 38,
+                            "table_id": 40,
                             "verbose_name": null,
                             "warning_text": null
                         }
@@ -879,13 +452,205 @@
                     {
                         "__TableColumn__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                            "column_name": "event",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
                             },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 142,
+                            "is_active": true,
+                            "is_dttm": false,
+                            "python_date_format": null,
+                            "table_id": 38,
+                            "type": "STRING",
+                            "verbose_name": null
+                        }
+                    },
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "label",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 143,
+                            "is_active": true,
+                            "is_dttm": false,
+                            "python_date_format": null,
+                            "table_id": 38,
+                            "type": "STRING",
+                            "verbose_name": null
+                        }
+                    },
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "number",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 144,
+                            "is_active": true,
+                            "is_dttm": false,
+                            "python_date_format": null,
+                            "table_id": 38,
+                            "type": "INT",
+                            "verbose_name": null
+                        }
+                    },
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
                             "column_name": "repository",
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 145,
+                            "is_active": true,
+                            "is_dttm": false,
+                            "python_date_format": null,
+                            "table_id": 38,
+                            "type": "STRING",
+                            "verbose_name": null
+                        }
+                    },
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "time",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 146,
+                            "is_active": true,
+                            "is_dttm": true,
+                            "python_date_format": null,
+                            "table_id": 38,
+                            "type": "DATETIME",
+                            "verbose_name": null
+                        }
+                    }
+                ],
+                "database_id": 2,
+                "default_endpoint": null,
+                "description": null,
+                "fetch_values_predicate": null,
+                "filter_select_enabled": false,
+                "is_sqllab_view": true,
+                "main_dttm_col": null,
+                "metrics": [
+                    {
+                        "__SqlMetric__": {
+                            "changed_by_fk": 1,
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "d3format": null,
+                            "description": null,
+                            "expression": "count(*)",
+                            "id": 39,
+                            "is_restricted": false,
+                            "metric_name": "count",
+                            "metric_type": null,
+                            "table_id": 38,
+                            "verbose_name": null,
+                            "warning_text": null
+                        }
+                    }
+                ],
+                "offset": 0,
+                "params": "{\"remote_id\": 38, \"database_name\": \"metadata\"}",
+                "schema": "public",
+                "sql": "SELECT\n    repository,\n    number,\n    CONCAT(repository, '/pull/', number) AS label,\n    event,\n    time\n    FROM (\n        SELECT\n        CONCAT(repository_owner, '/', repository_name) AS repository,\n        number,\n        created_at AS created_datetime,\n        merged_at AS merged_datetime,\n        CASE\n            WHEN merged_at IS NOT NULL THEN NULL\n            ELSE closed_at\n        END AS closed_datetime,\n        closed_at,\n        merged_at\n        FROM pull_requests) t\n    JOIN LATERAL (\n        VALUES('created', t.created_datetime), ('closed', t.closed_datetime), ('merged', t.merged_datetime)) s(event, time) ON TRUE",
+                "table_name": "pr_workflow-6tUyZn8RC",
+                "template_params": "{}"
+            }
+        },
+        {
+            "__SqlaTable__": {
+                "cache_timeout": null,
+                "columns": [
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "created_at",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 127,
+                            "is_active": true,
+                            "is_dttm": true,
+                            "python_date_format": null,
+                            "table_id": 34,
+                            "type": "DATETIME",
+                            "verbose_name": null
+                        }
+                    },
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "days",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 128,
+                            "is_active": true,
+                            "is_dttm": false,
+                            "python_date_format": null,
+                            "table_id": 34,
+                            "type": "FLOAT",
+                            "verbose_name": null
+                        }
+                    },
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "merged_at",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
                             },
                             "database_expression": null,
                             "description": null,
@@ -894,23 +659,20 @@
                             "groupby": true,
                             "id": 129,
                             "is_active": true,
-                            "is_dttm": false,
+                            "is_dttm": true,
                             "python_date_format": null,
                             "table_id": 34,
-                            "type": "STRING",
+                            "type": "DATETIME",
                             "verbose_name": null
                         }
                     },
                     {
                         "__TableColumn__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "resolution_type",
+                            "column_name": "repository",
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:31"
                             },
                             "database_expression": null,
                             "description": null,
@@ -938,12 +700,9 @@
                     {
                         "__SqlMetric__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:30"
                             },
                             "d3format": null,
                             "description": null,
@@ -953,6 +712,242 @@
                             "metric_name": "count",
                             "metric_type": null,
                             "table_id": 34,
+                            "verbose_name": null,
+                            "warning_text": null
+                        }
+                    }
+                ],
+                "offset": 0,
+                "params": "{\"remote_id\": 37, \"database_name\": \"metadata\"}",
+                "schema": "public",
+                "sql": "SELECT\r\n    CONCAT(repository_owner, '/', repository_name) AS repository,\r\n    created_at,\r\n    merged_at, \r\n    extract(epoch from (merged_at - created_at)) / (3600.00 *24) as days\r\nFROM pull_requests \r\nWHERE merged_at IS NOT NULL",
+                "table_name": "admin admin-pr_by_days-XSb1QtdX4",
+                "template_params": "{}"
+            }
+        },
+        {
+            "__SqlaTable__": {
+                "cache_timeout": null,
+                "columns": [
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "created_at",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 135,
+                            "is_active": true,
+                            "is_dttm": true,
+                            "python_date_format": null,
+                            "table_id": 36,
+                            "type": "DATETIME",
+                            "verbose_name": null
+                        }
+                    },
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "id",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 136,
+                            "is_active": true,
+                            "is_dttm": false,
+                            "python_date_format": null,
+                            "table_id": 36,
+                            "type": "INT",
+                            "verbose_name": null
+                        }
+                    },
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "merged_at",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 137,
+                            "is_active": true,
+                            "is_dttm": true,
+                            "python_date_format": null,
+                            "table_id": 36,
+                            "type": "DATETIME",
+                            "verbose_name": null
+                        }
+                    },
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "repository",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 138,
+                            "is_active": true,
+                            "is_dttm": false,
+                            "python_date_format": null,
+                            "table_id": 36,
+                            "type": "STRING",
+                            "verbose_name": null
+                        }
+                    },
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "time_to_merge",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 139,
+                            "is_active": true,
+                            "is_dttm": true,
+                            "python_date_format": null,
+                            "table_id": 36,
+                            "type": null,
+                            "verbose_name": null
+                        }
+                    }
+                ],
+                "database_id": 2,
+                "default_endpoint": null,
+                "description": null,
+                "fetch_values_predicate": null,
+                "filter_select_enabled": false,
+                "is_sqllab_view": true,
+                "main_dttm_col": null,
+                "metrics": [
+                    {
+                        "__SqlMetric__": {
+                            "changed_by_fk": 1,
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "d3format": null,
+                            "description": null,
+                            "expression": "count(*)",
+                            "id": 37,
+                            "is_restricted": false,
+                            "metric_name": "count",
+                            "metric_type": null,
+                            "table_id": 36,
+                            "verbose_name": null,
+                            "warning_text": null
+                        }
+                    }
+                ],
+                "offset": 0,
+                "params": "{\"remote_id\": 36, \"database_name\": \"metadata\"}",
+                "schema": "public",
+                "sql": "SELECT id, CONCAT(repository_owner, '/', repository_name) AS repository, created_at, merged_at, merged_at - created_at as time_to_merge\r\nFROM pull_requests \r\nWHERE merged_at IS NOT NULL",
+                "table_name": "pr_time_to_merge_median-_4s5FrIrI",
+                "template_params": "{}"
+            }
+        },
+        {
+            "__SqlaTable__": {
+                "cache_timeout": null,
+                "columns": [
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "repository",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 140,
+                            "is_active": true,
+                            "is_dttm": false,
+                            "python_date_format": null,
+                            "table_id": 37,
+                            "type": "STRING",
+                            "verbose_name": null
+                        }
+                    },
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "resolution_type",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 141,
+                            "is_active": true,
+                            "is_dttm": false,
+                            "python_date_format": null,
+                            "table_id": 37,
+                            "type": "STRING",
+                            "verbose_name": null
+                        }
+                    }
+                ],
+                "database_id": 2,
+                "default_endpoint": null,
+                "description": null,
+                "fetch_values_predicate": null,
+                "filter_select_enabled": false,
+                "is_sqllab_view": true,
+                "main_dttm_col": null,
+                "metrics": [
+                    {
+                        "__SqlMetric__": {
+                            "changed_by_fk": 1,
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "d3format": null,
+                            "description": null,
+                            "expression": "count(*)",
+                            "id": 38,
+                            "is_restricted": false,
+                            "metric_name": "count",
+                            "metric_type": null,
+                            "table_id": 37,
                             "verbose_name": null,
                             "warning_text": null
                         }
@@ -973,168 +968,21 @@
                     {
                         "__TableColumn__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "repository",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 136,
-                            "is_active": true,
-                            "is_dttm": false,
-                            "python_date_format": null,
-                            "table_id": 36,
-                            "type": "STRING",
-                            "verbose_name": null
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "merged",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 137,
-                            "is_active": true,
-                            "is_dttm": false,
-                            "python_date_format": null,
-                            "table_id": 36,
-                            "type": "INT",
-                            "verbose_name": null
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "closed",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 138,
-                            "is_active": true,
-                            "is_dttm": false,
-                            "python_date_format": null,
-                            "table_id": 36,
-                            "type": "INT",
-                            "verbose_name": null
-                        }
-                    }
-                ],
-                "database_id": 2,
-                "default_endpoint": null,
-                "description": null,
-                "fetch_values_predicate": null,
-                "filter_select_enabled": false,
-                "is_sqllab_view": true,
-                "main_dttm_col": null,
-                "metrics": [
-                    {
-                        "__SqlMetric__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "d3format": null,
-                            "description": null,
-                            "expression": "count(*)",
-                            "id": 37,
-                            "is_restricted": false,
-                            "metric_name": "count",
-                            "metric_type": null,
-                            "table_id": 36,
-                            "verbose_name": null,
-                            "warning_text": null
-                        }
-                    }
-                ],
-                "offset": 0,
-                "params": "{\"remote_id\": 31, \"database_name\": \"metadata\"}",
-                "schema": "public",
-                "sql": "SELECT CONCAT(repository_owner, '/', repository_name) AS repository, COUNT(merged_at) AS merged, (COUNT(closed_at) - COUNT(merged_at)) AS closed\nFROM pull_requests\nWHERE state <> 'open'\nGROUP BY repository",
-                "table_name": "pr_status-8jUyYteDu",
-                "template_params": "{}"
-            }
-        },
-        {
-            "__SqlaTable__": {
-                "cache_timeout": null,
-                "columns": [
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "repository",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 139,
-                            "is_active": true,
-                            "is_dttm": false,
-                            "python_date_format": null,
-                            "table_id": 37,
-                            "type": "STRING",
-                            "verbose_name": null
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
                             "column_name": "created_at",
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:31"
                             },
                             "database_expression": null,
                             "description": null,
                             "expression": "",
                             "filterable": true,
                             "groupby": true,
-                            "id": 140,
+                            "id": 147,
                             "is_active": true,
                             "is_dttm": true,
                             "python_date_format": null,
-                            "table_id": 37,
+                            "table_id": 39,
                             "type": "DATETIME",
                             "verbose_name": null
                         }
@@ -1142,50 +990,88 @@
                     {
                         "__TableColumn__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "column_name": "merged_at",
-                            "created_by_fk": 1,
-                            "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
-                            "database_expression": null,
-                            "description": null,
-                            "expression": "",
-                            "filterable": true,
-                            "groupby": true,
-                            "id": 141,
-                            "is_active": true,
-                            "is_dttm": true,
-                            "python_date_format": null,
-                            "table_id": 37,
-                            "type": "DATETIME",
-                            "verbose_name": null
-                        }
-                    },
-                    {
-                        "__TableColumn__": {
-                            "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
                             "column_name": "days",
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:31"
                             },
                             "database_expression": null,
                             "description": null,
                             "expression": "",
                             "filterable": true,
                             "groupby": true,
-                            "id": 142,
+                            "id": 148,
                             "is_active": true,
                             "is_dttm": false,
                             "python_date_format": null,
-                            "table_id": 37,
+                            "table_id": 39,
                             "type": "FLOAT",
+                            "verbose_name": null
+                        }
+                    },
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "id",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 149,
+                            "is_active": true,
+                            "is_dttm": false,
+                            "python_date_format": null,
+                            "table_id": 39,
+                            "type": "INT",
+                            "verbose_name": null
+                        }
+                    },
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "merged_at",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 150,
+                            "is_active": true,
+                            "is_dttm": true,
+                            "python_date_format": null,
+                            "table_id": 39,
+                            "type": "DATETIME",
+                            "verbose_name": null
+                        }
+                    },
+                    {
+                        "__TableColumn__": {
+                            "changed_by_fk": 1,
+                            "column_name": "repository",
+                            "created_by_fk": 1,
+                            "created_on": {
+                                "__datetime__": "2019-08-14T11:30:31"
+                            },
+                            "database_expression": null,
+                            "description": null,
+                            "expression": "",
+                            "filterable": true,
+                            "groupby": true,
+                            "id": 151,
+                            "is_active": true,
+                            "is_dttm": false,
+                            "python_date_format": null,
+                            "table_id": 39,
+                            "type": "STRING",
                             "verbose_name": null
                         }
                     }
@@ -1201,31 +1087,28 @@
                     {
                         "__SqlMetric__": {
                             "changed_by_fk": 1,
-                            "changed_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
-                            },
                             "created_by_fk": 1,
                             "created_on": {
-                                "__datetime__": "2019-07-17T10:56:28"
+                                "__datetime__": "2019-08-14T11:30:31"
                             },
                             "d3format": null,
                             "description": null,
                             "expression": "count(*)",
-                            "id": 38,
+                            "id": 40,
                             "is_restricted": false,
                             "metric_name": "count",
                             "metric_type": null,
-                            "table_id": 37,
+                            "table_id": 39,
                             "verbose_name": null,
                             "warning_text": null
                         }
                     }
                 ],
                 "offset": 0,
-                "params": "{\"remote_id\": 37, \"database_name\": \"metadata\"}",
+                "params": "{\"remote_id\": 35, \"database_name\": \"metadata\"}",
                 "schema": "public",
-                "sql": "SELECT\r\n    CONCAT(repository_owner, '/', repository_name) AS repository,\r\n    created_at,\r\n    merged_at, \r\n    extract(epoch from (merged_at - created_at)) / (3600.00 *24) as days\r\nFROM pull_requests \r\nWHERE merged_at IS NOT NULL",
-                "table_name": "admin admin-pr_by_days-XSb1QtdX4",
+                "sql": "SELECT\r\n    id,\r\n    CONCAT(repository_owner, '/', repository_name) AS repository,\r\n    created_at,\r\n    merged_at, \r\n    extract(epoch from (merged_at - created_at)) / (3600.00 *24) as days\r\nFROM pull_requests \r\nWHERE merged_at IS NOT NULL",
+                "table_name": "pr_time_to_merge-ejLXE2oaX",
                 "template_params": "{}"
             }
         }


### PR DESCRIPTION
Fix: #140

Looks like this dashboard wasn't updated after sorting fix too.
Anyway it's better to review this PR by running it because it updated not only the sql query but columns in it and the chart.

New query is:
```
SELECT
    CONCAT(repository_owner, '/', repository_name) AS repository,
    'merged' AS mtype,
    1 AS value,
    created_at
FROM pull_requests
WHERE merged_at IS NOT NULL
UNION
SELECT
    CONCAT(repository_owner, '/', repository_name) AS repository,
    'closed' AS mtype,
    1 AS value,
    created_at
FROM pull_requests
WHERE closed_at IS NOT NULL AND merged_at IS NULL
UNION
SELECT
    CONCAT(repository_owner, '/', repository_name) AS repository,
    'opened' AS mtype,
    1 AS value,
    created_at
FROM pull_requests
WHERE closed_at IS NULL
```

Old query was:
```
SELECT CONCAT(repository_owner, '/', repository_name) AS repository, created_at, merged_at, closed_at
FROM pull_requests
```

New chart:

<img width="1406" alt="Screenshot 2019-08-13 at 19 43 34" src="https://user-images.githubusercontent.com/406916/62964702-cfae5980-be03-11e9-9e3a-6126d0816b13.png">
