### PR TITLE
Fix development mode in docker for macOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Superset updated to v0.34.0rc1 which brings many improvements and bug fixes ([#250](https://github.com/src-d/sourced-ui/issues/250))
 
+### Changed
+
+- Improve speed of development mode on macOs ([#266](https://github.com/src-d/sourced-ui/pull/266))
+
 </details>
 
 ## [v0.5.0](https://github.com/src-d/sourced-ui/releases/tag/v0.5.0) - 2019-08-20

--- a/Makefile
+++ b/Makefile
@@ -30,25 +30,18 @@ DOCKER_PUSH_LATEST ?=
 
 # Tools
 STAT := stat -c
-
-
-# Set the user as root inside of the container to have permissions to change
-# internal `superset` UID and GUID, and make it match the host user.
-# It will grant write access to the data from the volumes,
-# inside of the container and on host file system (see #221)
-LOGIN_USER := 0
 ifeq ($(shell uname),Darwin)
 	STAT := stat -f
-	# In OSX there's no problem if the host user and the internal user are
-	# different when reading and accessing data trough docker volumes.
-	LOGIN_USER := superset
 endif
 
 SOURCED_UI_ABS_PATH := $(shell pwd)
+# Get UID on host machine, it will be used inside a container to change
+# internal `superset` UID and GUID, and make it match the host user.
+# It will grant write access to the data from the volumes,
+# inside of the container and on host file system (see #221)
 LOCAL_USER := $(shell $(STAT) "%u" superset/superset)
 export SOURCED_UI_ABS_PATH
 export LOCAL_USER
-export LOGIN_USER
 
 
 # Build information

--- a/srcd/contrib/docker/docker-compose.override.yml
+++ b/srcd/contrib/docker/docker-compose.override.yml
@@ -1,13 +1,23 @@
 version: '3.2'
 services:
   sourced-ui:
-    user: ${LOGIN_USER:-superset}:${LOGIN_USER:-superset}
+    # run container as root instead of superset user defined in Dockerfile
+    user: 0:0
     volumes:
-      - ${SOURCED_UI_ABS_PATH}/superset/superset:/home/superset/superset
+      - type: bind
+        source: ${SOURCED_UI_ABS_PATH}/superset/superset
+        target: /home/superset/superset
+        consistency: delegated
       - ${SOURCED_UI_ABS_PATH}/superset/dashboards:/home/superset/dashboards
       - ${SOURCED_UI_ABS_PATH}/superset/contrib/docker/superset_config.py:/home/superset/superset/superset_config.py
-      - ${SOURCED_UI_ABS_PATH}/superset/contrib/docker/bootstrap.py:/home/superset/bootstrap.py
       - ${SOURCED_UI_ABS_PATH}/superset/contrib/docker/docker-entrypoint.sh:/entrypoint.sh
+      - type: volume
+        source: node_modules
+        target: /home/superset/superset/assets/node_modules
     environment:
       SUPERSET_ENV: development
       LOCAL_USER: ${LOCAL_USER:-}
+
+volumes:
+  node_modules:
+    external: false

--- a/superset/contrib/docker/docker-entrypoint.sh
+++ b/superset/contrib/docker/docker-entrypoint.sh
@@ -25,6 +25,7 @@ if [ "`whoami`" = "root" ] && [ -n "$LOCAL_USER" ]; then
     find . -group superset -exec chgrp $LOCAL_USER '{}' \;
     groupmod -g $LOCAL_USER superset
     usermod -u $LOCAL_USER superset
+    chown -R superset superset/assets/node_modules
 
     su -c "/entrypoint.sh" superset
     exit $?
@@ -42,7 +43,7 @@ elif [ "$SUPERSET_ENV" = "development" ]; then
     # `webpack-dev-server` will serve the UI from the port 8088, and it will proxy
     # non-asset requests to `Flask`, wich is listening at the port 8081
     # Doing so, updates to asset sources will be reflected in-browser without a refresh.
-    (cd superset/assets/ && npm ci)
+    (cd superset/assets/ && npm install)
     (cd superset/assets/ && npm run dev-server -- --host=0.0.0.0 --port=8088 --supersetPort=8081) &
     FLASK_ENV=development FLASK_APP=superset:app flask run -p 8081 --with-threads --reload --debugger --host=0.0.0.0
 elif [ "$SUPERSET_ENV" = "production" ]; then


### PR DESCRIPTION
I wasn't able to run sourced-ui container in dev mode on my machine.
It took more than 10m to reach `npm ci` step with consistent close to
100% CPU load.

This commit fixes it by:
- Mounting source code with `consistency: delegated` which is the faster
mode to bind mount
- Use docker volume for `node_modules` to avoid syncing it with host
file system at all

Required changes:
- Use root user in dev mode always, not only for Linux
- Set superset user to `node_modules` volume, by default only root has
access to it
- Replace `npm ci` with `npm install` because `npm ci` removes
`node_modules` directory before starting installing dependencies. But
mounted directory can't be removed.

Signed-off-by: Maxim Sukharev <max@smacker.ru>




---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file
