### PR TITLE
Spark query cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Added
 
 - Superset updated to v0.34.0rc1 which brings many improvements and bug fixes ([#250](https://github.com/src-d/sourced-ui/issues/250))
+- Add support for Spark query cancelation ([#223](https://github.com/src-d/sourced-ui/issues/223))
 
 </details>
 

--- a/superset/requirements-dev.txt
+++ b/superset/requirements-dev.txt
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
--e git+https://github.com/src-d/PyHive.git@v0.7.0-srcd1#egg=PyHive
+-e git+https://github.com/se7entyse7en/PyHive.git@operation-handle-cancellation#egg=PyHive
 black==19.3b0
 coverage==4.5.3
 flake8-import-order==0.18.1

--- a/superset/requirements-dev.txt
+++ b/superset/requirements-dev.txt
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
--e git+https://github.com/se7entyse7en/PyHive.git@operation-handle-cancellation#egg=PyHive
+-e git+https://github.com/src-d/PyHive.git@v0.7.0-srcd2#egg=PyHive
 black==19.3b0
 coverage==4.5.3
 flake8-import-order==0.18.1

--- a/superset/superset/db_engine_specs/hive.py
+++ b/superset/superset/db_engine_specs/hive.py
@@ -457,6 +457,7 @@ class SparkSQLEngineSpec(HiveEngineSpec):
             if (
                 len(op_err.args) > 0
                 and isinstance(op_err.args[0], ttypes.TFetchResultsResp)
+                # pylint: disable=no-member
                 and op_err.args[0].status.errorMessage == cancelation_error_msg
             ):
                 logging.warning("Query has been cancelled, returning empty result")

--- a/superset/superset/sql_lab.py
+++ b/superset/superset/sql_lab.py
@@ -270,6 +270,7 @@ def execute_sql_statements(
     with closing(engine.raw_connection()) as conn:
         with closing(conn.cursor()) as cursor:
             query.connection_id = db_engine_spec.get_connection_id(cursor)
+            session.commit()
             statement_count = len(statements)
             for i, statement in enumerate(statements):
                 # check if the query was stopped

--- a/superset/superset/sql_lab.py
+++ b/superset/superset/sql_lab.py
@@ -369,10 +369,11 @@ def execute_sql_statements(
 
 
 def cancel_query(query, user_name):
-    logging.info('Query with id `%s` has connection id `%s`',
-                 query.id, query.connection_id)
+    logging.info(
+        "Query with id `%s` has connection id `%s`", query.id, query.connection_id
+    )
     if not query.connection_id:
-        logging.info('No connection id found, query cancellation skipped')
+        logging.info("No connection id found, query cancellation skipped")
         return
 
     database = query.database
@@ -386,5 +387,5 @@ def cancel_query(query, user_name):
 
     with closing(engine.raw_connection()) as conn:
         with closing(conn.cursor()) as cursor:
-            logging.info('Calling `cancel_query` on db engine')
+            logging.info("Calling `cancel_query` on db engine")
             db_engine_spec.cancel_query(cursor, query)

--- a/superset/superset/sql_lab.py
+++ b/superset/superset/sql_lab.py
@@ -368,7 +368,10 @@ def execute_sql_statements(
 
 
 def cancel_query(query, user_name):
+    logging.info('Query with id `%s` has connection id `%s`',
+                 query.id, query.connection_id)
     if not query.connection_id:
+        logging.info('No connection id found, query cancellation skipped')
         return
 
     database = query.database
@@ -382,4 +385,5 @@ def cancel_query(query, user_name):
 
     with closing(engine.raw_connection()) as conn:
         with closing(conn.cursor()) as cursor:
+            logging.info('Calling `cancel_query` on db engine')
             db_engine_spec.cancel_query(cursor, query)

--- a/superset/superset/views/core.py
+++ b/superset/superset/views/core.py
@@ -2435,7 +2435,7 @@ class Superset(BaseSupersetView):
             logging.info("Committed status change for query with id `%s`", query.id)
             sql_lab.cancel_query(query, g.user.username if g.user else None)
         except Exception as e:
-            return json_error_response('{}'.format(e))
+            return json_error_response("{}".format(e))
         return self.json_response("OK")
 
     @has_access_api

--- a/superset/superset/views/core.py
+++ b/superset/superset/views/core.py
@@ -2428,11 +2428,14 @@ class Superset(BaseSupersetView):
         client_id = request.form.get("client_id")
         try:
             query = db.session.query(Query).filter_by(client_id=client_id).one()
+            logging.info("Query retrieved with id `%s`", query.id)
             query.status = QueryStatus.STOPPED
+
             db.session.commit()
+            logging.info("Committed status change for query with id `%s`", query.id)
             sql_lab.cancel_query(query, g.user.username if g.user else None)
-        except Exception:
-            pass
+        except Exception as e:
+            return json_error_response('{}'.format(e))
         return self.json_response("OK")
 
     @has_access_api


### PR DESCRIPTION
Closes #223.
Depends on https://github.com/src-d/PyHive/pull/2.

This PR adds support for query cancellation by canceling the underlying Spark job. This is done by saving in the query object the corresponding json serialized `operationHandle` in the `extra` field. This `operationHandle` is then retrieved, marshaled and sent to Thrift server to request the cancelation.

This also adds some logging and sets the log level and log file for celery worker.

At celery layer the task ends correctly without raising any error:

```
[2019-08-27 13:59:30,711: INFO/MainProcess] Received task: sql_lab.get_sql_results[95b522b4-2336-492a-9784-baadce9f1cc1]
[2019-08-27 13:59:31,098: INFO/MainProcess] Parsing with sqlparse statement SELECT
    r.repository_id AS repo,
    c.commit_author_when AS date,
    cm.file_path AS path,
    UAST_EXTRACT(UAST(f.blob_content, 'Go', '//uast:Import/Path'), 'Value') AS imports
FROM
    repositories AS r
    NATURAL JOIN ref_commits AS rc
    NATURAL JOIN commits AS c
    NATURAL JOIN commit_files AS cm
    NATURAL JOIN files AS f
WHERE rc.ref_name = 'HEAD'
    AND f.file_path REGEXP('.*.go$')
    AND NOT IS_VENDOR(f.file_path)
    AND NOT IS_BINARY(f.blob_content)
    AND f.blob_size < 1000000
[2019-08-27 13:59:31,109: INFO/MainProcess] Executing 1 statement(s)
[2019-08-27 13:59:31,109: INFO/MainProcess] Set query to 'running'
[2019-08-27 13:59:31,109: INFO/MainProcess] Database.get_sqla_engine(). Masked URL: sparksql://gsc:10000/default
[2019-08-27 13:59:31,448: INFO/MainProcess] USE `default`
[2019-08-27 13:59:32,221: INFO/MainProcess] Running statement 1 out of 1
[2019-08-27 13:59:32,244: INFO/MainProcess] Parsing with sqlparse statement SELECT
    r.repository_id AS repo,
    c.commit_author_when AS date,
    cm.file_path AS path,
    UAST_EXTRACT(UAST(f.blob_content, 'Go', '//uast:Import/Path'), 'Value') AS imports
FROM
    repositories AS r
    NATURAL JOIN ref_commits AS rc
    NATURAL JOIN commits AS c
    NATURAL JOIN commit_files AS cm
    NATURAL JOIN files AS f
WHERE rc.ref_name = 'HEAD'
    AND f.file_path REGEXP('.*.go$')
    AND NOT IS_VENDOR(f.file_path)
    AND NOT IS_BINARY(f.blob_content)
    AND f.blob_size < 1000000
[2019-08-27 13:59:32,256: INFO/MainProcess] Parsing with sqlparse statement SELECT
    r.repository_id AS repo,
    c.commit_author_when AS date,
    cm.file_path AS path,
    UAST_EXTRACT(UAST(f.blob_content, 'Go', '//uast:Import/Path'), 'Value') AS imports
FROM
    repositories AS r
    NATURAL JOIN ref_commits AS rc
    NATURAL JOIN commits AS c
    NATURAL JOIN commit_files AS cm
    NATURAL JOIN files AS f
WHERE rc.ref_name = 'HEAD'
    AND f.file_path REGEXP('.*.go$')
    AND NOT IS_VENDOR(f.file_path)
    AND NOT IS_BINARY(f.blob_content)
    AND f.blob_size < 1000000
[2019-08-27 13:59:32,265: INFO/MainProcess] Running query:
SELECT
    r.repository_id AS repo,
    c.commit_author_when AS date,
    cm.file_path AS path,
    UAST_EXTRACT(UAST(f.blob_content, 'Go', '//uast:Import/Path'), 'Value') AS imports
FROM
    repositories AS r
    NATURAL JOIN ref_commits AS rc
    NATURAL JOIN commits AS c
    NATURAL JOIN commit_files AS cm
    NATURAL JOIN files AS f
WHERE rc.ref_name = 'HEAD'
    AND f.file_path REGEXP('.*.go$')
    AND NOT IS_VENDOR(f.file_path)
    AND NOT IS_BINARY(f.blob_content)
    AND f.blob_size < 1000000 LIMIT 100000
[2019-08-27 13:59:32,266: INFO/MainProcess] SELECT
    r.repository_id AS repo,
    c.commit_author_when AS date,
    cm.file_path AS path,
    UAST_EXTRACT(UAST(f.blob_content, 'Go', '//uast:Import/Path'), 'Value') AS imports
FROM
    repositories AS r
    NATURAL JOIN ref_commits AS rc
    NATURAL JOIN commits AS c
    NATURAL JOIN commit_files AS cm
    NATURAL JOIN files AS f
WHERE rc.ref_name = 'HEAD'
    AND f.file_path REGEXP('.*.go$')
    AND NOT IS_VENDOR(f.file_path)
    AND NOT IS_BINARY(f.blob_content)
    AND f.blob_size < 1000000 LIMIT 100000
[2019-08-27 13:59:32,272: INFO/MainProcess] Handling cursor
[2019-08-27 13:59:32,334: INFO/MainProcess] Current operation handles: [{'operation_id': {'guid': 'È\x88\x8e°u\x85OL\x84bÚãORÿ\x86', 'secret': 'f´\x10£a\x1eNI\x95ä@ø?ÝâÂ'}, 'operation_type': 0, 'has_result_set': True, 'modified_row_count': None}]
[2019-08-27 13:59:35,859: WARNING/MainProcess] An exception occured while fetching data, returning empty result
[2019-08-27 13:59:36,194: INFO/MainProcess] Storing results in results backend, key: 0368a910-337e-4d2a-b50a-f3c788322976
[2019-08-27 13:59:36,227: INFO/MainProcess] Task sql_lab.get_sql_results[95b522b4-2336-492a-9784-baadce9f1cc1] succeeded in 5.507471300006728s: None
```

At Spark level it's possible to see that the job is canceled by looking at the dashboard: http://localhost:4040/jobs:

<img width="1440" alt="Screenshot 2019-08-27 at 16 05 52" src="https://user-images.githubusercontent.com/5599208/63778146-93d7c180-c8e4-11e9-90a4-62d1090f7c62.png">

On the other hand some exception is not handled by `gsc`:

```
sourced-ui_1    | 2019-08-27 13:59:30,464:INFO:root:Parsing with sqlparse statement SELECT
sourced-ui_1    |     r.repository_id AS repo,
sourced-ui_1    |     c.commit_author_when AS date,
sourced-ui_1    |     cm.file_path AS path,
sourced-ui_1    |     UAST_EXTRACT(UAST(f.blob_content, 'Go', '//uast:Import/Path'), 'Value') AS imports
sourced-ui_1    | FROM
sourced-ui_1    |     repositories AS r
sourced-ui_1    |     NATURAL JOIN ref_commits AS rc
sourced-ui_1    |     NATURAL JOIN commits AS c
sourced-ui_1    |     NATURAL JOIN commit_files AS cm
sourced-ui_1    |     NATURAL JOIN files AS f
sourced-ui_1    | WHERE rc.ref_name = 'HEAD'
sourced-ui_1    |     AND f.file_path REGEXP('.*.go$')
sourced-ui_1    |     AND NOT IS_VENDOR(f.file_path)
sourced-ui_1    |     AND NOT IS_BINARY(f.blob_content)
sourced-ui_1    |     AND f.blob_size < 1000000
sourced-ui_1    | 2019-08-27 13:59:30,543:INFO:root:Parsing with sqlparse statement SELECT
sourced-ui_1    |     r.repository_id AS repo,
sourced-ui_1    |     c.commit_author_when AS date,
sourced-ui_1    |     cm.file_path AS path,
sourced-ui_1    |     UAST_EXTRACT(UAST(f.blob_content, 'Go', '//uast:Import/Path'), 'Value') AS imports
sourced-ui_1    | FROM
sourced-ui_1    |     repositories AS r
sourced-ui_1    |     NATURAL JOIN ref_commits AS rc
sourced-ui_1    |     NATURAL JOIN commits AS c
sourced-ui_1    |     NATURAL JOIN commit_files AS cm
sourced-ui_1    |     NATURAL JOIN files AS f
sourced-ui_1    | WHERE rc.ref_name = 'HEAD'
sourced-ui_1    |     AND f.file_path REGEXP('.*.go$')
sourced-ui_1    |     AND NOT IS_VENDOR(f.file_path)
sourced-ui_1    |     AND NOT IS_BINARY(f.blob_content)
sourced-ui_1    |     AND f.blob_size < 1000000
sourced-ui_1    | 2019-08-27 13:59:30,602:INFO:root:Triggering query_id: 2
sourced-ui_1    | 2019-08-27 13:59:30,617:INFO:root:Running query on a Celery worker
gsc_1           | 2019-08-27 13:59:31 INFO  ThriftCLIService:243 - Client protocol version: HIVE_CLI_SERVICE_PROTOCOL_V6
gsc_1           | 2019-08-27 13:59:31 INFO  SessionState:641 - Created HDFS directory: /tmp/hive/superset
gsc_1           | 2019-08-27 13:59:31 INFO  SessionState:641 - Created local directory: /tmp/d10bef94-f4ac-4a03-a7dd-79fb5fb23895_resources
gsc_1           | 2019-08-27 13:59:31 INFO  SessionState:641 - Created HDFS directory: /tmp/hive/superset/d10bef94-f4ac-4a03-a7dd-79fb5fb23895
gsc_1           | 2019-08-27 13:59:31 INFO  SessionState:641 - Created local directory: /tmp/root/d10bef94-f4ac-4a03-a7dd-79fb5fb23895
gsc_1           | 2019-08-27 13:59:31 INFO  SessionState:641 - Created HDFS directory: /tmp/hive/superset/d10bef94-f4ac-4a03-a7dd-79fb5fb23895/_tmp_space.db
gsc_1           | 2019-08-27 13:59:31 INFO  HiveSessionImpl:318 - Operation log session directory is created: /tmp/root/operation_logs/d10bef94-f4ac-4a03-a7dd-79fb5fb23895
gsc_1           | 2019-08-27 13:59:31 INFO  SparkExecuteStatementOperation:54 - Running query 'USE `default`' with 1ddc7292-c160-4d74-a7b0-f0c932a124d8
gsc_1           | 2019-08-27 13:59:32 INFO  CodeGenerator:54 - Code generated in 378.3003 ms
gsc_1           | 2019-08-27 13:59:32 INFO  DAGScheduler:54 - Asked to cancel job group 1ddc7292-c160-4d74-a7b0-f0c932a124d8
gsc_1           | 2019-08-27 13:59:32 INFO  SparkExecuteStatementOperation:54 - Running query 'SELECT
gsc_1           |     r.repository_id AS repo,
gsc_1           |     c.commit_author_when AS date,
gsc_1           |     cm.file_path AS path,
gsc_1           |     UAST_EXTRACT(UAST(f.blob_content, 'Go', '//uast:Import/Path'), 'Value') AS imports
gsc_1           | FROM
gsc_1           |     repositories AS r
gsc_1           |     NATURAL JOIN ref_commits AS rc
gsc_1           |     NATURAL JOIN commits AS c
gsc_1           |     NATURAL JOIN commit_files AS cm
gsc_1           |     NATURAL JOIN files AS f
gsc_1           | WHERE rc.ref_name = 'HEAD'
gsc_1           |     AND f.file_path REGEXP('.*.go$')
gsc_1           |     AND NOT IS_VENDOR(f.file_path)
gsc_1           |     AND NOT IS_BINARY(f.blob_content)
gsc_1           |     AND f.blob_size < 1000000 LIMIT 100000' with 19b28028-c118-4cff-8e9f-83887ad073a9
gsc_1           | 2019-08-27 13:59:33 INFO  CodeGenerator:54 - Code generated in 162.9486 ms
sourced-ui_1    | 2019-08-27 13:59:34,320:INFO:root:Requested stop query for client id `u3t9XvZtm`
sourced-ui_1    | 2019-08-27 13:59:34,335:INFO:root:Query retrieved with id `2`
sourced-ui_1    | 2019-08-27 13:59:34,393:INFO:root:Committed status change for query with id `2`
sourced-ui_1    | 2019-08-27 13:59:34,408:INFO:root:Query with id `2` has connection id `1`
sourced-ui_1    | 2019-08-27 13:59:34,430:INFO:root:Database.get_sqla_engine(). Masked URL: sparksql://gsc:10000/default
gsc_1           | 2019-08-27 13:59:34 INFO  CodeGenerator:54 - Code generated in 103.8353 ms
gsc_1           | 2019-08-27 13:59:34 INFO  CodeGenerator:54 - Code generated in 30.1023 ms
gsc_1           | 2019-08-27 13:59:34 INFO  ThriftCLIService:243 - Client protocol version: HIVE_CLI_SERVICE_PROTOCOL_V6
gsc_1           | 2019-08-27 13:59:35 INFO  SessionState:641 - Created local directory: /tmp/62dd5a06-063a-4128-8ec0-d762268c4249_resources
gsc_1           | 2019-08-27 13:59:35 INFO  SessionState:641 - Created HDFS directory: /tmp/hive/superset/62dd5a06-063a-4128-8ec0-d762268c4249
gsc_1           | 2019-08-27 13:59:35 INFO  SessionState:641 - Created local directory: /tmp/root/62dd5a06-063a-4128-8ec0-d762268c4249
gsc_1           | 2019-08-27 13:59:35 INFO  SessionState:641 - Created HDFS directory: /tmp/hive/superset/62dd5a06-063a-4128-8ec0-d762268c4249/_tmp_space.db
gsc_1           | 2019-08-27 13:59:35 INFO  HiveSessionImpl:318 - Operation log session directory is created: /tmp/root/operation_logs/62dd5a06-063a-4128-8ec0-d762268c4249
sourced-ui_1    | 2019-08-27 13:59:35,375:INFO:pyhive.hive:USE `default`
gsc_1           | 2019-08-27 13:59:35 INFO  SparkExecuteStatementOperation:54 - Running query 'USE `default`' with 21cd9a0e-bb90-4ab7-8ddd-d25feeabe492
gsc_1           | 2019-08-27 13:59:35 INFO  DAGScheduler:54 - Asked to cancel job group 21cd9a0e-bb90-4ab7-8ddd-d25feeabe492
sourced-ui_1    | 2019-08-27 13:59:35,471:INFO:root:Calling `cancel_query` on db engine
sourced-ui_1    | 2019-08-27 13:59:35,471:INFO:root:Cancelling query with id: `2`
sourced-ui_1    | 2019-08-27 13:59:35,472:INFO:root:Cancelling operation handle: `{'operation_id': {'guid': 'È\x88\x8e°u\x85OL\x84bÚãORÿ\x86', 'secret': 'f´\x10£a\x1eNI\x95ä@ø?ÝâÂ'}, 'operation_type': 0, 'has_result_set': True, 'modified_row_count': None}`
gsc_1           | 2019-08-27 13:59:35 INFO  SparkExecuteStatementOperation:54 - Cancel 'SELECT
gsc_1           |     r.repository_id AS repo,
gsc_1           |     c.commit_author_when AS date,
gsc_1           |     cm.file_path AS path,
gsc_1           |     UAST_EXTRACT(UAST(f.blob_content, 'Go', '//uast:Import/Path'), 'Value') AS imports
gsc_1           | FROM
gsc_1           |     repositories AS r
gsc_1           |     NATURAL JOIN ref_commits AS rc
gsc_1           |     NATURAL JOIN commits AS c
gsc_1           |     NATURAL JOIN commit_files AS cm
gsc_1           |     NATURAL JOIN files AS f
gsc_1           | WHERE rc.ref_name = 'HEAD'
gsc_1           |     AND f.file_path REGEXP('.*.go$')
gsc_1           |     AND NOT IS_VENDOR(f.file_path)
gsc_1           |     AND NOT IS_BINARY(f.blob_content)
gsc_1           |     AND f.blob_size < 1000000 LIMIT 100000' with 19b28028-c118-4cff-8e9f-83887ad073a9
gsc_1           | 2019-08-27 13:59:35 INFO  DAGScheduler:54 - Asked to cancel job group 19b28028-c118-4cff-8e9f-83887ad073a9
gsc_1           | 2019-08-27 13:59:35 INFO  SparkContext:54 - Starting job: run at AccessController.java:0
gsc_1           | 2019-08-27 13:59:35 INFO  ContextCleaner:54 - Cleaned accumulator 0
gsc_1           | 2019-08-27 13:59:35 ERROR SparkExecuteStatementOperation:91 - Error executing query, currentState CANCELED,
gsc_1           | java.lang.InterruptedException
gsc_1           | 	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1302)
gsc_1           | 	at scala.concurrent.impl.Promise$DefaultPromise.tryAwait(Promise.scala:202)
gsc_1           | 	at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:218)
gsc_1           | 	at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:153)
gsc_1           | 	at org.apache.spark.util.ThreadUtils$.awaitReady(ThreadUtils.scala:222)
gsc_1           | 	at org.apache.spark.scheduler.DAGScheduler.runJob(DAGScheduler.scala:633)
gsc_1           | 	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2034)
gsc_1           | 	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2055)
gsc_1           | 	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2074)
gsc_1           | 	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2099)
gsc_1           | 	at org.apache.spark.rdd.RDD$$anonfun$collect$1.apply(RDD.scala:945)
gsc_1           | 	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
gsc_1           | 	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:112)
gsc_1           | 	at org.apache.spark.rdd.RDD.withScope(RDD.scala:363)
gsc_1           | 	at org.apache.spark.rdd.RDD.collect(RDD.scala:944)
gsc_1           | 	at org.apache.spark.sql.execution.SparkPlan.executeCollect(SparkPlan.scala:297)
gsc_1           | 	at org.apache.spark.sql.Dataset.org$apache$spark$sql$Dataset$$collectFromPlan(Dataset.scala:3278)
gsc_1           | 	at org.apache.spark.sql.Dataset$$anonfun$collect$1.apply(Dataset.scala:2727)
gsc_1           | 	at org.apache.spark.sql.Dataset$$anonfun$collect$1.apply(Dataset.scala:2727)
gsc_1           | 	at org.apache.spark.sql.Dataset$$anonfun$52.apply(Dataset.scala:3259)
gsc_1           | 	at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:77)
gsc_1           | 	at org.apache.spark.sql.Dataset.withAction(Dataset.scala:3258)
gsc_1           | 	at org.apache.spark.sql.Dataset.collect(Dataset.scala:2727)
gsc_1           | 	at org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation.org$apache$spark$sql$hive$thriftserver$SparkExecuteStatementOperation$$execute(SparkExecuteStatementOperation.scala:246)
gsc_1           | 	at org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation$$anon$1$$anon$2.run(SparkExecuteStatementOperation.scala:175)
gsc_1           | 	at org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation$$anon$1$$anon$2.run(SparkExecuteStatementOperation.scala:171)
gsc_1           | 	at java.security.AccessController.doPrivileged(Native Method)
gsc_1           | 	at javax.security.auth.Subject.doAs(Subject.java:422)
gsc_1           | 	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1698)
gsc_1           | 	at org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation$$anon$1.run(SparkExecuteStatementOperation.scala:185)
gsc_1           | 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
gsc_1           | 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
gsc_1           | 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
gsc_1           | 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
gsc_1           | 	at java.lang.Thread.run(Thread.java:748)
gsc_1           | 2019-08-27 13:59:35 WARN  ThriftCLIService:630 - Error fetching results:
gsc_1           | org.apache.hive.service.cli.HiveSQLException: Expected state FINISHED, but found CANCELED
gsc_1           | 	at org.apache.hive.service.cli.operation.Operation.assertState(Operation.java:161)
gsc_1           | 	at org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation.getNextRowSet(SparkExecuteStatementOperation.scala:113)
gsc_1           | 	at org.apache.hive.service.cli.operation.OperationManager.getOperationNextRowSet(OperationManager.java:220)
gsc_1           | 	at org.apache.hive.service.cli.session.HiveSessionImpl.fetchResults(HiveSessionImpl.java:767)
gsc_1           | 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
gsc_1           | 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
gsc_1           | 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
gsc_1           | 	at java.lang.reflect.Method.invoke(Method.java:498)
gsc_1           | 	at org.apache.hive.service.cli.session.HiveSessionProxy.invoke(HiveSessionProxy.java:78)
gsc_1           | 	at org.apache.hive.service.cli.session.HiveSessionProxy.access$000(HiveSessionProxy.java:36)
gsc_1           | 	at org.apache.hive.service.cli.session.HiveSessionProxy$1.run(HiveSessionProxy.java:63)
gsc_1           | 	at java.security.AccessController.doPrivileged(Native Method)
gsc_1           | 	at javax.security.auth.Subject.doAs(Subject.java:422)
gsc_1           | 	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1698)
gsc_1           | 	at org.apache.hive.service.cli.session.HiveSessionProxy.invoke(HiveSessionProxy.java:59)
gsc_1           | 	at com.sun.proxy.$Proxy22.fetchResults(Unknown Source)
gsc_1           | 	at org.apache.hive.service.cli.CLIService.fetchResults(CLIService.java:455)
gsc_1           | 	at org.apache.hive.service.cli.thrift.ThriftCLIService.FetchResults(ThriftCLIService.java:621)
gsc_1           | 	at org.apache.hive.service.cli.thrift.TCLIService$Processor$FetchResults.getResult(TCLIService.java:1553)
gsc_1           | 	at org.apache.hive.service.cli.thrift.TCLIService$Processor$FetchResults.getResult(TCLIService.java:1538)
gsc_1           | 	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39)
gsc_1           | 	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39)
gsc_1           | 	at org.apache.hive.service.auth.TSetIpAddressProcessor.process(TSetIpAddressProcessor.java:53)
gsc_1           | 	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:286)
gsc_1           | 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
gsc_1           | 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
gsc_1           | 	at java.lang.Thread.run(Thread.java:748)
gsc_1           | 2019-08-27 13:59:35 ERROR SparkExecuteStatementOperation:179 - Error running hive query:
gsc_1           | org.apache.hive.service.cli.HiveSQLException: Illegal Operation state transition from CANCELED to ERROR
gsc_1           | 	at org.apache.hive.service.cli.OperationState.validateTransition(OperationState.java:92)
gsc_1           | 	at org.apache.hive.service.cli.OperationState.validateTransition(OperationState.java:98)
gsc_1           | 	at org.apache.hive.service.cli.operation.Operation.setState(Operation.java:126)
gsc_1           | 	at org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation.org$apache$spark$sql$hive$thriftserver$SparkExecuteStatementOperation$$execute(SparkExecuteStatementOperation.scala:266)
gsc_1           | 	at org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation$$anon$1$$anon$2.run(SparkExecuteStatementOperation.scala:175)
gsc_1           | 	at org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation$$anon$1$$anon$2.run(SparkExecuteStatementOperation.scala:171)
gsc_1           | 	at java.security.AccessController.doPrivileged(Native Method)
gsc_1           | 	at javax.security.auth.Subject.doAs(Subject.java:422)
gsc_1           | 	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1698)
gsc_1           | 	at org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation$$anon$1.run(SparkExecuteStatementOperation.scala:185)
gsc_1           | 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
gsc_1           | 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
gsc_1           | 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
gsc_1           | 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
gsc_1           | 	at java.lang.Thread.run(Thread.java:748)
gsc_1           | 2019-08-27 13:59:35 INFO  DAGScheduler:54 - Registering RDD 2 (run at AccessController.java:0)
gsc_1           | 2019-08-27 13:59:35 INFO  DAGScheduler:54 - Got job 0 (run at AccessController.java:0) with 1 output partitions
gsc_1           | 2019-08-27 13:59:35 INFO  DAGScheduler:54 - Final stage: ResultStage 1 (run at AccessController.java:0)
gsc_1           | 2019-08-27 13:59:35 INFO  SparkExecuteStatementOperation:54 - Result Schema: StructType(StructField(repo,StringType,true), StructField(date,TimestampType,true), StructField(path,StringType,true), StructField(imports,ArrayType(StringType,true),true))
gsc_1           | 2019-08-27 13:59:35 INFO  DAGScheduler:54 - Parents of final stage: List(ShuffleMapStage 0)
gsc_1           | 2019-08-27 13:59:35 INFO  DAGScheduler:54 - Missing parents: List(ShuffleMapStage 0)
gsc_1           | 2019-08-27 13:59:35 INFO  DAGScheduler:54 - Submitting ShuffleMapStage 0 (MapPartitionsRDD[2] at run at AccessController.java:0), which has no missing parents
gsc_1           | 2019-08-27 13:59:36 INFO  DAGScheduler:54 - Asked to cancel job group 19b28028-c118-4cff-8e9f-83887ad073a9
gsc_1           | 2019-08-27 13:59:36 INFO  MemoryStore:54 - Block broadcast_0 stored as values in memory (estimated size 6.7 KB, free 366.3 MB)
gsc_1           | 2019-08-27 13:59:36 INFO  MemoryStore:54 - Block broadcast_0_piece0 stored as bytes in memory (estimated size 3.8 KB, free 366.3 MB)
gsc_1           | 2019-08-27 13:59:36 INFO  BlockManagerInfo:54 - Added broadcast_0_piece0 in memory on bc56b54576bf:38809 (size: 3.8 KB, free: 366.3 MB)
gsc_1           | 2019-08-27 13:59:36 INFO  SparkContext:54 - Created broadcast 0 from broadcast at DAGScheduler.scala:1039
gsc_1           | 2019-08-27 13:59:36 INFO  DAGScheduler:54 - Submitting 1 missing tasks from ShuffleMapStage 0 (MapPartitionsRDD[2] at run at AccessController.java:0) (first 15 tasks are for partitions Vector(0))
gsc_1           | 2019-08-27 13:59:36 INFO  TaskSchedulerImpl:54 - Adding task set 0.0 with 1 tasks
gsc_1           | 2019-08-27 13:59:36 INFO  TaskSetManager:54 - Starting task 0.0 in stage 0.0 (TID 0, localhost, executor driver, partition 0, PROCESS_LOCAL, 10396 bytes)
gsc_1           | 2019-08-27 13:59:36 INFO  TaskSchedulerImpl:54 - Cancelling stage 0
gsc_1           | 2019-08-27 13:59:36 INFO  Executor:54 - Executor is trying to kill task 0.0 in stage 0.0 (TID 0), reason: Stage cancelled
gsc_1           | 2019-08-27 13:59:36 INFO  TaskSchedulerImpl:54 - Stage 0 was cancelled
gsc_1           | 2019-08-27 13:59:36 INFO  Executor:54 - Running task 0.0 in stage 0.0 (TID 0)
gsc_1           | 2019-08-27 13:59:36 INFO  DAGScheduler:54 - ShuffleMapStage 0 (run at AccessController.java:0) failed in 0.543 s due to Job 0 cancelled part of cancelled job group 19b28028-c118-4cff-8e9f-83887ad073a9
gsc_1           | 2019-08-27 13:59:36 INFO  Executor:54 - Fetching spark://bc56b54576bf:36451/jars/gitbase-spark-connector-enterprise-uber.jar with timestamp 1566914245093
gsc_1           | 2019-08-27 13:59:36 INFO  TransportClientFactory:267 - Successfully created connection to bc56b54576bf/172.31.0.9:36451 after 88 ms (0 ms spent in bootstraps)
gsc_1           | 2019-08-27 13:59:36 INFO  Utils:54 - Fetching spark://bc56b54576bf:36451/jars/gitbase-spark-connector-enterprise-uber.jar to /tmp/spark-8ac04fdd-1031-4d4f-9e0f-5db04a411b25/userFiles-b7f9e9dc-0a08-450c-995a-bc06c59ac55d/fetchFileTemp4891356638895890777.tmp
gsc_1           | 2019-08-27 13:59:37 INFO  Executor:54 - Adding file:/tmp/spark-8ac04fdd-1031-4d4f-9e0f-5db04a411b25/userFiles-b7f9e9dc-0a08-450c-995a-bc06c59ac55d/gitbase-spark-connector-enterprise-uber.jar to class loader
gsc_1           | 2019-08-27 13:59:37 INFO  Executor:54 - Executor killed task 0.0 in stage 0.0 (TID 0), reason: Stage cancelled
gsc_1           | 2019-08-27 13:59:37 WARN  TaskSetManager:66 - Lost task 0.0 in stage 0.0 (TID 0, localhost, executor driver): TaskKilled (Stage cancelled)
gsc_1           | 2019-08-27 13:59:37 INFO  TaskSchedulerImpl:54 - Removed TaskSet 0.0, whose tasks have all completed, from pool
```
---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file
