### PR TITLE
Fix display of complex types from SparkSQL

### DIFF
--- a/superset/superset/db_engine_specs/hive.py
+++ b/superset/superset/db_engine_specs/hive.py
@@ -407,6 +407,15 @@ class SparkSQLEngineSpec(HiveEngineSpec):
         return BaseEngineSpec.get_view_names(inspector, schema)
 
     @classmethod
+    def expand_data(cls, columns, data):
+        """
+        This method allows to display nested fields
+        Hive spec uses types defined in Presto for this
+        and they don't match values returned by SparkSQL
+        """
+        return BaseEngineSpec.expand_data(columns, data)
+
+    @classmethod
     def select_star(
         cls,
         my_db,


### PR DESCRIPTION
Fix: #268

Superset 0.34 introduced richer display of complex types but it's
implemented only for Presto and can't be reused for SparkSQL.

Signed-off-by: Maxim Sukharev <max@smacker.ru>




---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [x] This PR contains changes that do not require a mention in the CHANGELOG file
