### PR TITLE
Use exec to start gunicorn in entrypoint.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 
 - Improve speed of development mode on macOs ([#266](https://github.com/src-d/sourced-ui/pull/266))
+- Make gunicorn to catch SIGTERM correctly which speed-ups stop command and makes container exit with correct exit code ([#239](https://github.com/src-d/sourced-ui/issues/239))
 
 </details>
 

--- a/superset/contrib/docker/docker-entrypoint.sh
+++ b/superset/contrib/docker/docker-entrypoint.sh
@@ -48,7 +48,7 @@ elif [ "$SUPERSET_ENV" = "development" ]; then
     FLASK_ENV=development FLASK_APP=superset:app flask run -p 8081 --with-threads --reload --debugger --host=0.0.0.0
 elif [ "$SUPERSET_ENV" = "production" ]; then
     celery worker --app=superset.sql_lab:celery_app --pool=gevent -Ofair &
-    gunicorn --bind  0.0.0.0:8088 \
+    exec gunicorn --bind 0.0.0.0:8088 \
         --workers $((2 * $(getconf _NPROCESSORS_ONLN) + 1)) \
         --timeout 300 \
         --limit-request-line 0 \


### PR DESCRIPTION
Fix #239

Use exec command to start gunicorn which allows it to catch SIGTERM and
other signals correctly.

Ref: https://unix.stackexchange.com/questions/146756/forward-sigterm-to-child-in-bash

```
$ time docker stop 00ea877ea0f8
00ea877ea0f8

real	0m2.293s
user	0m0.045s
sys	0m0.023s
```

```
srcd-z28ty2hp_sourced-ui_1     /entrypoint.sh                   Exit 0
```

Signed-off-by: Maxim Sukharev <max@smacker.ru>




---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file
