### PR TITLE
Dockerfile optimized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Improve speed of development mode on macOs ([#266](https://github.com/src-d/sourced-ui/pull/266))
 - Make gunicorn to catch SIGTERM correctly which speed-ups stop command and makes container exit with correct exit code ([#239](https://github.com/src-d/sourced-ui/issues/239))
+- Optimize size of Docker image ([#275](https://github.com/src-d/sourced-ui/pull/275))
 
 </details>
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ endif
 # IS_RELEASE is "true" if tag is semantic version and not a pre-release
 IS_RELEASE := $(shell echo $(VERSION) | grep -q -E '^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$$' && echo "true" || true)
 
-all: build
+all: build build-dev
 
 # Clean, and copy src-d files in the superset repository
 .PHONY: patch

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,8 @@ dev-prepare: set-override watch
 .PHONY: patch
 build: patch
 	docker build -t $(DOCKER_IMAGE_NAME):$(VERSION) -f superset/contrib/docker/Dockerfile $(SUPERSET_DIR)
+build-dev: patch
+	docker build -t $(DOCKER_IMAGE_NAME):$(VERSION)-dev -f superset/contrib/docker/Dockerfile $(SUPERSET_DIR) --build-arg DEV_BUILD=true
 
 .PHONY: docker-validate
 docker-validate:

--- a/superset/contrib/docker/Dockerfile
+++ b/superset/contrib/docker/Dockerfile
@@ -18,11 +18,13 @@ FROM node:12 AS static
 
 WORKDIR /home/superset
 
-COPY superset/assets superset/assets
+# Install deps and cache them
+COPY superset/assets/package*.json superset/assets/
+RUN cd superset/assets && npm ci
 
-RUN cd superset/assets \
-        && npm ci \
-        && npm run build
+# Build
+COPY superset/assets superset/assets
+RUN cd superset/assets && npm run build
 
 FROM python:3.6 AS wheels
 

--- a/superset/contrib/docker/Dockerfile
+++ b/superset/contrib/docker/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM node:12 AS static
+FROM node:10 AS static
 
 WORKDIR /home/superset
 

--- a/superset/contrib/docker/Dockerfile
+++ b/superset/contrib/docker/Dockerfile
@@ -14,7 +14,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.6-jessie
+FROM node:12 AS static
+
+WORKDIR /home/superset
+
+COPY superset/assets superset/assets
+
+RUN cd superset/assets \
+        && npm ci \
+        && npm run build
+
+FROM python:3.6 AS wheels
+
+WORKDIR /home/superset
+
+RUN apt-get update -y
+RUN apt-get install -y libsasl2-dev
+
+COPY requirements.txt .
+COPY requirements-dev.txt .
+COPY contrib/docker/requirements-extra.txt .
+
+RUN pip install --upgrade setuptools pip \
+        && pip wheel --wheel-dir=/wheels \
+        -r requirements.txt -r requirements-dev.txt -r requirements-extra.txt
+
+FROM python:3.6-slim
+
+ARG DEV_BUILD
 
 RUN useradd --user-group --create-home --no-log-init --shell /bin/bash superset
 
@@ -24,48 +51,42 @@ ENV LANG=C.UTF-8 \
 
 RUN apt-get update -y
 
-# Install dependencies to fix `curl https support error` and `elaying package configuration warning`
-RUN apt-get install -y apt-transport-https apt-utils
-
+# Install git as it is used for requirements from Github
+RUN apt-get install -y git
 # Install superset dependencies
-# https://superset.incubator.apache.org/installation.html#os-dependencies
-RUN apt-get install -y build-essential libssl-dev \
-    libffi-dev python3-dev libsasl2-dev libldap2-dev libsasl2-2 libsasl2-modules-gssapi-mit libxi-dev
+RUN apt-get install -y libsasl2-dev libsasl2-2 libsasl2-modules-gssapi-mit
 
-# Install extra useful tool for development
-RUN apt-get install -y vim less postgresql-client redis-tools
-
-# Install nodejs for custom build
-# https://superset.incubator.apache.org/installation.html#making-your-own-build
-# https://nodejs.org/en/download/package-manager/
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
-    && apt-get install -y nodejs
+RUN if [ "$DEV_BUILD" = "true" ]; \
+        then apt-get install -y curl && \
+        curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+        && apt-get install -y nodejs vim less postgresql-client redis-tools; fi
 
 WORKDIR /home/superset
+
+COPY --from=wheels /wheels /wheels
 
 COPY requirements.txt .
 COPY requirements-dev.txt .
 COPY contrib/docker/requirements-extra.txt .
 
 RUN pip install --upgrade setuptools pip \
-    && pip install -r requirements.txt -r requirements-dev.txt -r requirements-extra.txt \
-    && rm -rf /root/.cache/pip
+        && pip install --no-index --find-links=/wheels \
+        -r requirements.txt -r requirements-dev.txt -r requirements-extra.txt \
+        && rm -rf /wheels
 
-RUN pip install gevent
+RUN if [ "$DEV_BUILD" != "true" ]; \
+        then apt-get -y --purge autoremove git; fi
 
 COPY --chown=superset:superset superset superset
 COPY --chown=superset:superset dashboards dashboards
 
 ENV PATH=/home/superset/superset/bin:$PATH \
     PYTHONPATH=/home/superset/:$PYTHONPATH \
-    SUPERSET_CONFIG_PATH=/home/superset/superset/superset_config.py
+        SUPERSET_CONFIG_PATH=/home/superset/superset/superset_config.py
+
+COPY --chown=superset:superset --from=static /home/superset/superset/assets/dist superset/assets/dist
 
 USER superset
-
-RUN cd superset/assets \
-    && npm ci \
-    && npm run build \
-    && rm -rf node_modules
 
 COPY contrib/docker/superset_config.py ./superset/
 COPY contrib/docker/bootstrap.py .


### PR DESCRIPTION
Closes #273.
This doesn't address #272.

The `Dockerfile` has been modified in order to reduce the final image size. This is achieved by using multi-stage build. There are two builders:
1. for static files,
2. for python wheels.

The first builder compiles the static files and permits the final image to avoid installing nodejs for the production version. This also improves the usage of docker caching for this step that is really heavy.

The second builder builds the python wheels to be used in the final image. This permits to use the slim image version.

The final image depends on the build arg `DEV_BUILD`: if `DEV_BUILD` is `true`, then also os dev dependencies are installed, otherwise, they're not. The Makefile provides the `build-dev` target.

The production image size has decreased from `1.76GB` to `945MB` (decrease `>800MB`, -46%).
The development image size has decreased from `1.76GB` to `1.1GB` (decrease `>650MB`, -37.5%).

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file
