### PR TITLE
Force docker to pull FROM images when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,9 +92,9 @@ dev-prepare: set-override watch
 # Create docker image
 .PHONY: patch
 build: patch
-	docker build -t $(DOCKER_IMAGE_NAME):$(VERSION) -f superset/contrib/docker/Dockerfile $(SUPERSET_DIR)
+	docker build --pull -t $(DOCKER_IMAGE_NAME):$(VERSION) -f superset/contrib/docker/Dockerfile $(SUPERSET_DIR)
 build-dev: patch
-	docker build -t $(DOCKER_IMAGE_NAME):$(VERSION)-dev -f superset/contrib/docker/Dockerfile $(SUPERSET_DIR) --build-arg DEV_BUILD=true
+	docker build --pull -t $(DOCKER_IMAGE_NAME):$(VERSION)-dev -f superset/contrib/docker/Dockerfile $(SUPERSET_DIR) --build-arg DEV_BUILD=true
 
 .PHONY: docker-validate
 docker-validate:

--- a/superset/contrib/docker/Dockerfile
+++ b/superset/contrib/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN cd superset/assets && npm ci
 COPY superset/assets superset/assets
 RUN cd superset/assets && npm run build
 
-FROM python:3.6 AS wheels
+FROM python:3.6-buster AS wheels
 
 WORKDIR /home/superset
 
@@ -41,7 +41,7 @@ RUN pip install --upgrade setuptools pip \
         && pip wheel --wheel-dir=/wheels \
         -r requirements.txt -r requirements-dev.txt -r requirements-extra.txt
 
-FROM python:3.6-slim
+FROM python:3.6-slim-buster
 
 ARG DEV_BUILD
 


### PR DESCRIPTION
After fixing MariaDB issue https://github.com/src-d/sourced-ui/pull/279 we found again that `libmariadbclient18` was missing in some others mate's PCs.

Turns out that `libmariadbclient18` was removed from `debian buster` (base of `python:3.6-slim`), but when building the image with an old version of `python:3.6` and `python:3.6-slim`, it failed.

The solution appeared deleting current `python:3.6` and `python:3.6-slim` images, and building again, which pulled the proper (and new) versions of `python:3.6` and `python:3.6-slim`.

Adding `--pull` in our `docker build` commands will do it by default, to avoid building using old versions of our FROM images.

some info: https://www.databasesandlife.com/docker-build-pull-option

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [x] This PR contains changes that do not require a mention in the CHANGELOG file
