### PR TITLE
Document how to run dev env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,11 @@
 # Changelog
 
 ## [Unreleased]
-<details>
-  <summary>
-    Changes that have landed in master but are not yet released.
-    Click to see more.
-  </summary>
 
-</details>
+### Internal
+
+- Improve docs about development mode to [run source{d} with hot reloading](./CONTRIBUTING.md#run-sourced-ce-for-development-with-hot-reloading). Previous docs didn't explain how to build the `sourced-ui` development image.
+
 
 ## [v0.6.0](https://github.com/src-d/sourced-ui/releases/tag/v0.6.0) - 2019-09-16
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,14 @@ directories will trigger a refresh in your browser with the new code.
 (see [installation guide](https://docs.sourced.tech/community-edition/quickstart/2-install-sourced)
 if needed)
 
+1. Build the `srcd/sourced-ui:latest-dev` development image, with the sources of `sourced-ui`:
+
+    ```shell
+    $ make build-dev
+    ```
+
+    It will take some time to be ready (~5min).
+
 1. Run the watcher.
 
     <details>
@@ -136,6 +144,11 @@ if needed)
 
     The first time you launch it, it will take some time to build all the UI assets,
     you can see the progress of the build from `sourced-ui` logs (see next step).
+
+    It may happen that the hot reloading stops working with an error message
+    `Failed to compile` that cannot be solved modifying the source code.
+    It usually happens when switching between branches or stopping the watcher.
+    To fix it, you only need to ensure the watcher is running, and `init` again.
 
 1. To see `sourced-ui` logs (with `npm` errors and such), run:
 

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ docker-push-latest-release:
 .PHONY: clean
 clean:
 	rm -f "$(SUPERSET_DIR)/superset_config.py"
-	git clean -fd $(SUPERSET_DIR)
+	git clean -ffdx $(SUPERSET_DIR)
 	rm -f $(OVERRIDE_OUTPUT_PATH)
 	@if [ -f "$(OVERRIDE_BACKUP_PATH)" ]; then \
 		mv $(OVERRIDE_BACKUP_PATH) $(OVERRIDE_OUTPUT_PATH); \

--- a/srcd/contrib/docker/docker-compose.override.yml
+++ b/srcd/contrib/docker/docker-compose.override.yml
@@ -3,6 +3,7 @@ services:
   sourced-ui:
     # run container as root instead of superset user defined in Dockerfile
     user: 0:0
+    image: srcd/sourced-ui:latest-dev
     volumes:
       - type: bind
         source: ${SOURCED_UI_ABS_PATH}/superset/superset


### PR DESCRIPTION
Document how to run dev

The current way to run development environment with hot reloading uses the `srcd/sourced-ui` image required by `sourced` active config, which may be incorrect many times (if that version, and the current sources of `srcd-/sourced-ui` being tested mismatch in an incompatible way)

The proper way to run the dev environment requires to build the `srcd/sourced-ui:latest-dev` development image from sources and then use it for the hot reloading environment

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file
