### PR TITLE
Add celery mode for init the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Make celery workers to run as separate containers ([#269](https://github.com/src-d/sourced-ui/issues/269))
+
 ### Internal
 
 - Improve docs about development mode to [run source{d} with hot reloading](./CONTRIBUTING.md#run-sourced-ce-for-development-with-hot-reloading). Previous docs didn't explain how to build the `sourced-ui` development image.

--- a/README.md
+++ b/README.md
@@ -21,35 +21,35 @@ This repository contains the code for the [`srcd/sourced-ui`](https://hub.docker
 
 You can configure the Docker image using the following environment variables:
 
-| Environment Variable  | Description                                                     |
-|-----------------------|-----------------------------------------------------------------|
-| `ADMIN_LOGIN`         | Username for the admin user                                     |
-| `ADMIN_FIRST_NAME`    | First name of the admin user                                    |
-| `ADMIN_LAST_NAME`     | Last name of the admin user                                     |
-| `ADMIN_EMAIL`         | Email of the admin user                                         |
-| `ADMIN_PASSWORD`      | Password of the admin user                                      |
-| `BBLFSH_WEB_HOST`     | Hostname for bblfsh-web                                         |
-| `BBLFSH_WEB_PORT`     | Port for bblfsh-web                                             |
-| `GITBASE_HOST`        | Hostname for Gitbase                                            |
-| `GITBASE_PORT`        | Port for Gitbase                                                |
-| `GITBASE_DB`          | Database name for Gitbase                                       |
-| `GITBASE_USER`        | Username for Gitbase                                            |
-| `GITBASE_PASSWORD`    | Password for Gitbase                                            |
-| `POSTGRES_HOST`       | Hostname for Superset DB                                        |
-| `POSTGRES_PORT`       | Port for Superset DB                                            |
-| `POSTGRES_DB`         | Database for Superset DB                                        |
-| `POSTGRES_USER`       | Username for Superset DB                                        |
-| `POSTGRES_PASSWORD`   | Password for Superset DB                                        |
-| `REDIS_HOST`          | Hostname for Redis                                              |
-| `REDIS_PORT`          | Port for Redis                                                  |
-| `SUPERSET_ENV`        | Environment Superset runs in `production` or `development`      |
-| `SUPERSET_NO_INIT_DB` | Does not run the database init script if set to `true`          |
-| `SYNC_MODE`           | Adds metadata datasource and welcome dashboard if set to `true` |
-| `METADATA_HOST`       | Hostname for metadata DB (when `SYNC_MODE` is set to `true`)    |
-| `METADATA_PORT`       | Port for metadata DB (when `SYNC_MODE` is set to `true`)        |
-| `METADATA_USER`       | Username for metadata DB (when `SYNC_MODE` is set to `true`)    |
-| `METADATA_PASSWORD`   | Password for metadata DB (when `SYNC_MODE` is set to `true`)    |
-| `METADATA_DB`         | Database name for metadata (when `SYNC_MODE` is set to `true`)  |
+| Environment Variable  | Description                                                      |
+|-----------------------|------------------------------------------------------------------|
+| `ADMIN_LOGIN`         | Username for the admin user                                      |
+| `ADMIN_FIRST_NAME`    | First name of the admin user                                     |
+| `ADMIN_LAST_NAME`     | Last name of the admin user                                      |
+| `ADMIN_EMAIL`         | Email of the admin user                                          |
+| `ADMIN_PASSWORD`      | Password of the admin user                                       |
+| `BBLFSH_WEB_HOST`     | Hostname for bblfsh-web                                          |
+| `BBLFSH_WEB_PORT`     | Port for bblfsh-web                                              |
+| `GITBASE_HOST`        | Hostname for Gitbase                                             |
+| `GITBASE_PORT`        | Port for Gitbase                                                 |
+| `GITBASE_DB`          | Database name for Gitbase                                        |
+| `GITBASE_USER`        | Username for Gitbase                                             |
+| `GITBASE_PASSWORD`    | Password for Gitbase                                             |
+| `POSTGRES_HOST`       | Hostname for Superset DB                                         |
+| `POSTGRES_PORT`       | Port for Superset DB                                             |
+| `POSTGRES_DB`         | Database for Superset DB                                         |
+| `POSTGRES_USER`       | Username for Superset DB                                         |
+| `POSTGRES_PASSWORD`   | Password for Superset DB                                         |
+| `REDIS_HOST`          | Hostname for Redis                                               |
+| `REDIS_PORT`          | Port for Redis                                                   |
+| `SUPERSET_ENV`        | Environment Superset runs in `production`/`celery`/`development` |
+| `SUPERSET_NO_INIT_DB` | Does not run the database init script if set to `true`           |
+| `SYNC_MODE`           | Adds metadata datasource and welcome dashboard if set to `true`  |
+| `METADATA_HOST`       | Hostname for metadata DB (when `SYNC_MODE` is set to `true`)     |
+| `METADATA_PORT`       | Port for metadata DB (when `SYNC_MODE` is set to `true`)         |
+| `METADATA_USER`       | Username for metadata DB (when `SYNC_MODE` is set to `true`)     |
+| `METADATA_PASSWORD`   | Password for metadata DB (when `SYNC_MODE` is set to `true`)     |
+| `METADATA_DB`         | Database name for metadata (when `SYNC_MODE` is set to `true`)   |
 
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository contains the code for the [`srcd/sourced-ui`](https://hub.docker
 - Cancel database queries on stop ([#35](https://github.com/src-d/sourced-ui/issues/35)).
 - Creates datasources for gitbase and metadata db on bootstrap
 
+The image is designed to be deployed as two containers, one with `SUPERSET_ENV=production` and the other one with `SUPERSET_ENV=celery`. Take a look at the docker-compose.yml file in the [src-d/sourced-ce](https://github.com/src-d/sourced-ce/blob/master/docker-compose.yml) repository for more details.
 
 ### Environment Variables
 

--- a/srcd/contrib/docker/docker-compose.override.yml
+++ b/srcd/contrib/docker/docker-compose.override.yml
@@ -19,6 +19,12 @@ services:
       SUPERSET_ENV: development
       LOCAL_USER: ${LOCAL_USER:-}
 
+  sourced-ui-celery:
+    # disable separate celery container
+    image: tianon/true
+    entrypoint: 'true'
+    command: 'true'
+
 volumes:
   node_modules:
     external: false


### PR DESCRIPTION
This commit adds SUPERSET_ENV=celery which runs only celery worker
Current `production` environment doesn't start celery anymore

This allows to see logs and scale the workers.

The change is breaking and requires update of sourced-ce.

Ref: #269

Signed-off-by: Maxim Sukharev <max@smacker.ru>




---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file
