### PR TITLE
Remove python dev dependencies from the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Reduce the size of docker image ([#272](https://github.com/src-d/sourced-ui/issues/272))
+
 ## [v0.7.0](https://github.com/src-d/sourced-ui/releases/tag/v0.7.0) - 2019-09-26
 
 ### Changed

--- a/superset/contrib/docker/Dockerfile
+++ b/superset/contrib/docker/Dockerfile
@@ -28,6 +28,8 @@ RUN cd superset/assets && npm run build
 
 FROM python:3.6-buster AS wheels
 
+ARG DEV_BUILD
+
 WORKDIR /home/superset
 
 RUN apt-get update -y
@@ -39,7 +41,10 @@ COPY contrib/docker/requirements-extra.txt .
 
 RUN pip install --upgrade setuptools pip \
         && pip wheel --wheel-dir=/wheels \
-        -r requirements.txt -r requirements-dev.txt -r requirements-extra.txt
+        -r requirements.txt -r requirements-extra.txt
+
+RUN if [ "$DEV_BUILD" = "true" ]; \
+        then pip wheel --wheel-dir=/wheels -r requirements-dev.txt; fi
 
 FROM python:3.6-slim-buster
 
@@ -49,7 +54,7 @@ RUN useradd --user-group --create-home --no-log-init --shell /bin/bash superset
 
 # Configure environment
 ENV LANG=C.UTF-8 \
-    LC_ALL=C.UTF-8
+        LC_ALL=C.UTF-8
 
 RUN apt-get update -y
 
@@ -73,8 +78,12 @@ COPY contrib/docker/requirements-extra.txt .
 
 RUN pip install --upgrade setuptools pip \
         && pip install --no-index --find-links=/wheels \
-        -r requirements.txt -r requirements-dev.txt -r requirements-extra.txt \
-        && rm -rf /wheels
+        -r requirements.txt -r requirements-extra.txt
+
+RUN if [ "$DEV_BUILD" = "true" ]; \
+        then pip install --no-index --find-links=/wheels -r requirements-dev.txt; fi
+
+RUN rm -rf /wheels
 
 RUN if [ "$DEV_BUILD" != "true" ]; \
         then apt-get -y --purge autoremove git; fi
@@ -83,7 +92,7 @@ COPY --chown=superset:superset superset superset
 COPY --chown=superset:superset dashboards dashboards
 
 ENV PATH=/home/superset/superset/bin:$PATH \
-    PYTHONPATH=/home/superset/:$PYTHONPATH \
+        PYTHONPATH=/home/superset/:$PYTHONPATH \
         SUPERSET_CONFIG_PATH=/home/superset/superset/superset_config.py
 
 COPY --chown=superset:superset --from=static /home/superset/superset/assets/dist superset/assets/dist

--- a/superset/contrib/docker/requirements-extra.txt
+++ b/superset/contrib/docker/requirements-extra.txt
@@ -15,3 +15,14 @@
 # limitations under the License.
 #
 gevent==1.4.0
+# for superset&metadata DBs
+psycopg2-binary==2.7.5
+# for gitbase
+mysqlclient==1.4.2.post1
+# for gitbase-spark-connector
+sasl==0.2.1
+thrift_sasl==0.3.0
+thrift==0.11.0
+-e git+https://github.com/src-d/PyHive.git@v0.7.0-srcd2#egg=PyHive
+# for cache and queue
+redis==3.2.1

--- a/superset/requirements-dev.txt
+++ b/superset/requirements-dev.txt
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
--e git+https://github.com/src-d/PyHive.git@v0.7.0-srcd2#egg=PyHive
 black==19.3b0
 coverage==4.5.3
 flake8-import-order==0.18.1
@@ -23,19 +22,13 @@ flake8==3.7.7
 flask-cors==3.0.7
 ipdb==0.12
 mypy==0.670
-mysqlclient==1.4.2.post1
 nose==1.3.7
 pip-tools==3.7.0
 pre-commit==1.17.0
-psycopg2-binary==2.7.5
 pycodestyle==2.5.0
 pydruid==0.5.6
 pylint==1.9.2
-redis==3.2.1
 requests_kerberos>=0.12.0
 requests==2.22.0
-sasl==0.2.1
 statsd==3.3.0
-thrift_sasl==0.3.0
-thrift==0.11.0
 tox==3.11.1

--- a/superset/tox.ini
+++ b/superset/tox.ini
@@ -42,6 +42,7 @@ commands =
     nosetests -e load_examples_test {posargs}
 deps =
     -rrequirements.txt
+    -rcontrib/docker/requirements-extra.txt
     -rrequirements-dev.txt
 setenv =
     PYTHONPATH = {toxinidir}
@@ -133,12 +134,14 @@ deps =
 [testenv:py36-mysql]
 deps =
     -rrequirements.txt
+    -rcontrib/docker/requirements-extra.txt
     -rrequirements-dev.txt
     .[mysql]
 
 [testenv:py36-postgres]
 deps =
     -rrequirements.txt
+    -rcontrib/docker/requirements-extra.txt
     -rrequirements-dev.txt
     .[postgres]
 
@@ -147,6 +150,7 @@ commands =
     pylint superset
 deps =
     -rrequirements.txt
+    -rcontrib/docker/requirements-extra.txt
     -rrequirements-dev.txt
 
 [tox]


### PR DESCRIPTION
The production image size has decreased from `933MB` to `811MB`.

Fix: #272

Signed-off-by: Maxim Sukharev <max@smacker.ru>




---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file
