### PR TITLE
Bump docker-compose.override.yml version to 3.4

### DIFF
--- a/srcd/contrib/docker/docker-compose.override.yml
+++ b/srcd/contrib/docker/docker-compose.override.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: '3.4'
 services:
   sourced-ui:
     # run container as root instead of superset user defined in Dockerfile


### PR DESCRIPTION
We want to use it in srcd-ce to benifit from extension fields.
Different versions of file format produce an error.

Signed-off-by: Maxim Sukharev <max@smacker.ru>




---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [x] This PR contains changes that do not require a mention in the CHANGELOG file
