### PR TITLE
Enhance palettes for color blindness impairment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Reduce the size of docker image ([#272](https://github.com/src-d/sourced-ui/issues/272))
+- Make the current source{d} palettes accessible for color blindness impairments ([#302](https://github.com/src-d/sourced-ui/issues/302))
 
 ## [v0.7.0](https://github.com/src-d/sourced-ui/releases/tag/v0.7.0) - 2019-09-26
 

--- a/srcd/superset/assets/src/customization/colors.js
+++ b/srcd/superset/assets/src/customization/colors.js
@@ -24,14 +24,14 @@ const palette = {
   limeLightDeep: '#00b491',
   limeLight: '#00c8a1',
 
-  vanila: '#d024c6',
-  vanilaLight: '#e981e3',
+  vanila: '#00d6d1',
+  vanilaLight: '#00eae4',
 
-  navy: '#195dca',
-  navyLight: '#8fb5f1',
+  navy: '#05d600',
+  navyLight: '#05ea00',
 
-  gray: '#6d6e71',
-  grayLight: '#c6c7c8',
+  gray: '#3d3d3d',
+  grayLight: '#565656',
 };
 
 const colors = {


### PR DESCRIPTION
fix https://github.com/src-d/sourced-ui/issues/301

This PR only modifies `srcdMain` and `srcdSix` current palettes in order to make them accessible for color blindness impairment. It can be seen in the left chart below.

![image](https://user-images.githubusercontent.com/2437584/67032449-e62ea500-f113-11e9-9201-8fb36b55c37b.png)

The example at the right just shows how would it look like if https://github.com/src-d/sourced-ui/issues/303 is approved

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file
